### PR TITLE
fix: align prisma agent schema with API selections

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -16,33 +16,35 @@ datasource db {
 // ===================================================
 
 model Agent {
-  id          String     @id @default(uuid())
-  name        String
-  area        String
-  description String?
-  area        String?
-  uses        Int         @default(0)
-  downloads   Int         @default(0)
-  rewards     Int         @default(0)
-  stars       Float       @default(0)
-  votes       Int         @default(0)
+  id            String        @id @default(uuid())
+  name          String
+  type          String        @default("Analyst")
+  area          String
+  description   String?
+  uses          Int           @default(0)
+  downloads     Int           @default(0)
+  rewards       Int           @default(0)
+  stars         Float         @default(0)
+  votes         Int           @default(0)
   openaiAgentId String?
-  model         String?    @default("gpt-4.1-mini")
+  model         String?       @default("gpt-4.1-mini")
   instructions  String?
-  updatedAt   DateTime    @updatedAt
-  usages      AgentUsage[]
-  traces      AgentTrace[]
+  updatedAt     DateTime      @updatedAt
+  usages        AgentUsage[]
+  traces        AgentTrace[]
+  workflows     Workflow[]
 }
 
-model Metrics {
-  id         String  @id @default(uuid())
-  uses       Int     @default(0)
-  downloads  Int     @default(0)
-  rewards    Int     @default(0)
+model AgentUsage {
+  id        String   @id @default(uuid())
+  agentId   String
+  action    String
+  value     Float?
+  createdAt DateTime @default(now())
 
-  // Relación 1:1 con Agent
-  agentId    String  @unique
-  agent      Agent   @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  agent Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  @@index([agentId])
 }
 
 model Workflow {
@@ -53,24 +55,21 @@ model Workflow {
   platform  String   @default("OpenAI")
   action    String?
   value     Float?
-
-  // Relación N:1 con Agent
   agentId   String
   agent     Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
-
   createdAt DateTime @default(now())
 }
 
 model AgentTrace {
-  id         String   @id @default(uuid())
-  agentId    String
-  runId      String
-  status     String
-  grade      Float?
-  evaluator  String?
-  traceUrl   String?
-  input      String?
-  output     String?
-  createdAt  DateTime @default(now())
-  Agent      Agent   @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  id        String   @id @default(uuid())
+  agentId   String
+  runId     String
+  status    String
+  grade     Float?
+  evaluator String?
+  traceUrl  String?
+  input     String?
+  output    String?
+  createdAt DateTime @default(now())
+  agent     Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
## Summary
- add an explicit `type` column and inline metric counters to the Prisma `Agent` model used by the API
- introduce an `AgentUsage` relation and tidy related schema definitions so Prisma relations mirror the service layer
- refresh the database seed data to populate agent types and metric counters while cleaning related deletes

## Testing
- `DATABASE_URL="file:./dev.db" pnpm --filter api exec prisma db push`
- `DATABASE_URL="file:./dev.db" pnpm --filter api exec prisma db seed`
- `pnpm --filter api build` *(fails: pre-existing controller duplication and missing methods in src/agents/agents.controller.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e6adca3ea0832590cdba31067502f8