### PR TITLE
Compute agent type in services instead of selecting

### DIFF
--- a/apps/api/src/agents/agent-type.ts
+++ b/apps/api/src/agents/agent-type.ts
@@ -1,0 +1,7 @@
+const REPORT_KEYWORDS = [/reporte/i, /informe/i, /generador de informes/i]
+
+export type AgentType = 'Analyst' | 'Report'
+
+export function inferAgentType(name: string): AgentType {
+  return REPORT_KEYWORDS.some((pattern) => pattern.test(name)) ? 'Report' : 'Analyst'
+}

--- a/apps/api/src/agents/metrics/metrics.service.ts
+++ b/apps/api/src/agents/metrics/metrics.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
+import { inferAgentType, AgentType } from '../agent-type'
 import { PrismaService } from '../../prisma/prisma.service'
 
 type MetricField = 'uses' | 'downloads' | 'rewards'
@@ -13,7 +13,6 @@ const ACTION_MAP: Record<MetricField, 'use' | 'download' | 'reward'> = {
 const METRIC_SELECT = {
   id: true,
   name: true,
-  type: true,
   area: true,
   uses: true,
   downloads: true,
@@ -22,6 +21,11 @@ const METRIC_SELECT = {
   votes: true
 }
 
+const addAgentType = <T extends { name: string }>(agent: T): T & { type: AgentType } => ({
+  ...agent,
+  type: inferAgentType(agent.name)
+})
+
 @Injectable()
 export class MetricsService {
   constructor(private readonly prisma: PrismaService) {}
@@ -29,7 +33,7 @@ export class MetricsService {
   async increment(id: string, field: MetricField) {
     const action = ACTION_MAP[field]
 
-    return this.prisma.agent.update({
+    const agent = await this.prisma.agent.update({
       where: { id },
       data: {
         [field]: { increment: 1 },
@@ -41,6 +45,8 @@ export class MetricsService {
       },
       select: METRIC_SELECT
     })
+
+    return addAgentType(agent)
   }
 
   async rate(id: string, stars: number) {
@@ -53,7 +59,7 @@ export class MetricsService {
     const calculatedAverage = agent.votes === 0 ? safeStars : (agent.stars * agent.votes + safeStars) / (agent.votes + 1)
     const newAverage = Number(calculatedAverage.toFixed(2))
 
-    return this.prisma.agent.update({
+    const updated = await this.prisma.agent.update({
       where: { id },
       data: {
         stars: newAverage,
@@ -67,13 +73,17 @@ export class MetricsService {
       },
       select: METRIC_SELECT
     })
+
+    return addAgentType(updated)
   }
 
   async getMetrics(id: string) {
-    return this.prisma.agent.findUnique({
+    const agent = await this.prisma.agent.findUnique({
       where: { id },
       select: METRIC_SELECT
     })
+
+    return agent ? addAgentType(agent) : null
   }
 
 }


### PR DESCRIPTION
## Summary
- add a shared helper to infer an agent's type from its name
- update the agents and metrics services to derive the agent type after Prisma queries so it is no longer selected from the database

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6b102607483258c9e0380b646df16