### PR TITLE
Align agent taxonomy keywords across web and API

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,11 +1,12 @@
 import { PrismaClient } from '@prisma/client'
+import { AgentType, inferAgentType } from '../src/agents/agent-type'
 
 type AgentSeed = {
   id: string
   name: string
   area: string
   description: string
-  type?: 'Analyst' | 'Report'
+  type?: AgentType
   workflows: {
     id: string
     name: string
@@ -181,7 +182,7 @@ const agentsData: AgentSeed[] = [
     name: 'Generador de Informes',
     area: 'Dirección General',
     description: 'Automatiza la redacción de informes ejecutivos con datos actualizados y visualizaciones.',
-    type: 'Report',
+    type: 'reporting',
     workflows: [
       {
         id: 'wf-generador-informes-1',
@@ -197,7 +198,7 @@ const agentsData: AgentSeed[] = [
     name: 'Reporte de Análisis Técnico',
     area: 'Laboratorio y Control Técnico',
     description: 'Genera informes técnicos sobre mediciones y pruebas de laboratorios especializados.',
-    type: 'Report',
+    type: 'reporting',
     workflows: [
       {
         id: 'wf-reporte-tecnico-1',
@@ -213,7 +214,7 @@ const agentsData: AgentSeed[] = [
     name: 'Reporte de Auditoría',
     area: 'Auditoría y Control de Gestión',
     description: 'Consolida hallazgos de auditoría y produce planes de acción para áreas responsables.',
-    type: 'Report',
+    type: 'risk',
     workflows: [
       {
         id: 'wf-reporte-auditoria-1',
@@ -236,7 +237,7 @@ const agentsData: AgentSeed[] = [
     name: 'Reporte Económico',
     area: 'Economía y Tarifas',
     description: 'Analiza indicadores macroeconómicos y su impacto en los servicios de telecomunicaciones.',
-    type: 'Report',
+    type: 'financial',
     workflows: [
       {
         id: 'wf-reporte-economico-1',
@@ -252,7 +253,7 @@ const agentsData: AgentSeed[] = [
     name: 'Reporte de Licencias',
     area: 'Dirección Nacional de Servicios TIC',
     description: 'Centraliza renovaciones y vencimientos de licencias, avisando a las áreas responsables.',
-    type: 'Report',
+    type: 'regulatory',
     workflows: [
       {
         id: 'wf-reporte-licencias-1',
@@ -268,7 +269,7 @@ const agentsData: AgentSeed[] = [
     name: 'Informe Ejecutivo',
     area: 'Presidencia del ENACOM',
     description: 'Elabora presentaciones ejecutivas con foco en hitos y riesgos institucionales.',
-    type: 'Report',
+    type: 'reporting',
     workflows: [
       {
         id: 'wf-informe-ejecutivo-1',
@@ -284,7 +285,7 @@ const agentsData: AgentSeed[] = [
     name: 'Informe Trimestral',
     area: 'Planeamiento Institucional',
     description: 'Compila resultados del trimestre para el directorio y las áreas de seguimiento.',
-    type: 'Report',
+    type: 'reporting',
     workflows: [
       {
         id: 'wf-informe-trimestral-1',
@@ -303,12 +304,6 @@ const agentsData: AgentSeed[] = [
     ]
   }
 ]
-
-const reportKeywords = [/reporte/i, /informe/i, /generador de informes/i]
-
-function inferAgentType(name: string): 'Analyst' | 'Report' {
-  return reportKeywords.some((pattern) => pattern.test(name)) ? 'Report' : 'Analyst'
-}
 
 function randomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min

--- a/apps/api/src/agents/agent-type.ts
+++ b/apps/api/src/agents/agent-type.ts
@@ -1,7 +1,76 @@
-const REPORT_KEYWORDS = [/reporte/i, /informe/i, /generador de informes/i]
+export type AgentType =
+  | 'technical'
+  | 'financial'
+  | 'regulatory'
+  | 'reporting'
+  | 'risk'
+  | 'planning'
+  | 'general'
 
-export type AgentType = 'Analyst' | 'Report'
+const KEYWORD_GROUPS: { type: AgentType; patterns: RegExp[] }[] = [
+  {
+    type: 'technical',
+    patterns: [
+      /t[ée]cnic[oa]/i,
+      /infraestructura/i,
+      /radiocomunicaciones?/i,
+      /tecnolog[ií]a/i,
+      /ingenier[ií]a/i
+    ]
+  },
+  {
+    type: 'financial',
+    patterns: [
+      /financier[ao]/i,
+      /contable/i,
+      /presupuesto/i,
+      /presupuestari[ao]/i,
+      /tesorer[ií]a/i
+    ]
+  },
+  {
+    type: 'regulatory',
+    patterns: [
+      /licencias?/i,
+      /permisos?/i,
+      /regulatori[oa]/i,
+      /normativa/i,
+      /expediente/i
+    ]
+  },
+  {
+    type: 'reporting',
+    patterns: [
+      /informes?/i,
+      /reportes?/i,
+      /tablero/i,
+      /dashboard/i,
+      /resumen/i,
+      /ejecutivo/i
+    ]
+  },
+  {
+    type: 'risk',
+    patterns: [/riesgos?/i, /auditor[ií]a/i, /alerta/i]
+  },
+  {
+    type: 'planning',
+    patterns: [
+      /planificaci[oó]n/i,
+      /planificador/i,
+      /proyectos?/i,
+      /estrat[ée]gic[oa]/i,
+      /planeamiento/i
+    ]
+  }
+]
 
 export function inferAgentType(name: string): AgentType {
-  return REPORT_KEYWORDS.some((pattern) => pattern.test(name)) ? 'Report' : 'Analyst'
+  for (const group of KEYWORD_GROUPS) {
+    if (group.patterns.some((pattern) => pattern.test(name))) {
+      return group.type
+    }
+  }
+
+  return 'general'
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -27,8 +27,6 @@ type AgentSummary = {
 type AgentMetrics = AgentSummary & { type: AgentType }
 
 type GroupedAgents = Record<string, AgentMetrics[]>
-
-<<<<<<< HEAD
 type AgentTrace = {
   id: string
   runId: string
@@ -44,27 +42,6 @@ type AgentDetails = AgentMetrics & {
   description?: string | null
   updatedAt: string
   traces?: AgentTrace[]
-=======
-type AgentDetail = {
-  id: string
-  name: string
-  area: string
-  description: string | null
-  metrics: {
-    uses: number
-    downloads: number
-    rewards: number
-    stars: number
-    votes: number
-  }
-  workflows: {
-    id: string
-    name: string
-    status: string
-    model: string
-    platform: string
-  }[]
->>>>>>> main
 }
 
 export default function Page() {
@@ -382,4 +359,43 @@ function TraceCard({ trace }: { trace: AgentTrace }) {
       )}
     </div>
   )
+}
+
+const KEYWORD_TYPE_MAP: { keywords: string[]; type: AgentType }[] = [
+  {
+    type: 'technical',
+    keywords: ['técnico', 'tecnico', 'infraestructura', 'radiocomunicaciones', 'tecnología', 'tecnologias']
+  },
+  {
+    type: 'financial',
+    keywords: ['financiero', 'financiera', 'contable', 'presupuesto', 'presupuestaria', 'tesorería', 'tesoreria']
+  },
+  {
+    type: 'regulatory',
+    keywords: ['licencia', 'licencias', 'permiso', 'permisos', 'regulatorio', 'regulatoria', 'normativa', 'expediente']
+  },
+  {
+    type: 'reporting',
+    keywords: ['informe', 'informes', 'reporte', 'reportes', 'tablero', 'dashboard', 'resumen', 'ejecutivo']
+  },
+  {
+    type: 'risk',
+    keywords: ['riesgo', 'riesgos', 'auditoría', 'auditoria', 'alerta']
+  },
+  {
+    type: 'planning',
+    keywords: ['planificación', 'planificacion', 'planificador', 'proyecto', 'proyectos', 'estratégico', 'estrategico', 'planeamiento']
+  }
+]
+
+function inferAgentType(name: string): AgentType {
+  const normalized = name.toLowerCase()
+
+  for (const { keywords, type } of KEYWORD_TYPE_MAP) {
+    if (keywords.some((keyword) => normalized.includes(keyword))) {
+      return type
+    }
+  }
+
+  return 'general'
 }

--- a/apps/web/src/lib/agents-data.ts
+++ b/apps/web/src/lib/agents-data.ts
@@ -1,16 +1,56 @@
-export type AgentType = 'Analyst' | 'Report'
+export type AgentType =
+  | 'technical'
+  | 'financial'
+  | 'regulatory'
+  | 'reporting'
+  | 'risk'
+  | 'planning'
+  | 'general'
 
 export const agentGroups: Record<AgentType, { title: string; description: string }> = {
-  Analyst: {
-    title: 'Analistas Especializados',
+  technical: {
+    title: 'Operaciones Técnicas',
     description:
-      'Expertos del ENACOM en infraestructura, licencias, economía y planeamiento estratégico que impulsan la toma de decisiones.'
+      'Agentes enfocados en infraestructura, radiocomunicaciones y soporte tecnológico crítico para garantizar la conectividad.'
   },
-  Report: {
+  financial: {
+    title: 'Análisis Financiero y Contable',
+    description:
+      'Especialistas en presupuestos, ejecución financiera y auditorías que respaldan la sostenibilidad institucional.'
+  },
+  regulatory: {
+    title: 'Gestión Regulatoria y Licencias',
+    description:
+      'Referentes que acompañan los procesos de licencias, autorizaciones y cumplimiento normativo del sector TIC.'
+  },
+  reporting: {
     title: 'Reportes e Informes Institucionales',
     description:
-      'Documentos y tableros ejecutivos que consolidan hallazgos regulatorios, técnicos y financieros para la gestión pública.'
+      'Documentos ejecutivos y tableros que consolidan hallazgos regulatorios, técnicos y financieros para la gestión pública.'
+  },
+  risk: {
+    title: 'Gestión de Riesgos y Control',
+    description:
+      'Herramientas que monitorean riesgos operativos, alertas tempranas y mecanismos de control interno del ENACOM.'
+  },
+  planning: {
+    title: 'Planificación y Proyectos Estratégicos',
+    description:
+      'Agentes que coordinan la planificación, seguimiento de proyectos y evaluación de impacto de las iniciativas institucionales.'
+  },
+  general: {
+    title: 'Agentes Institucionales Generales',
+    description:
+      'Asistentes transversales que brindan soporte integral para diversas áreas y necesidades del organismo.'
   }
 }
 
-export const orderedAgentTypes: AgentType[] = ['Analyst', 'Report']
+export const orderedAgentTypes: AgentType[] = [
+  'technical',
+  'financial',
+  'regulatory',
+  'reporting',
+  'risk',
+  'planning',
+  'general'
+]


### PR DESCRIPTION
## Summary
- expand the shared `AgentType` taxonomy to cover technical, financial, regulatory, reporting, risk, planning, and general categories
- update the web dashboard metadata and keyword inference so agents are grouped under the new taxonomy
- reuse the API keyword inference within the Prisma seed and align seeded agent types with the updated values

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e6c6a9d3ac8325b0e92686e11727c2