### PR TITLE
feat(web): build interactive agents dashboard

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,104 +1,65 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { AgentCard } from '@agents-hub/ui'
-import { agentGroups, orderedAgentTypes, AgentType } from '../lib/agents-data'
-import { SectionTitle } from '../lib/ui'
-import AgentModal from '../components/AgentModal'
-import AgentChatKitEmbed from '../components/AgentChatKitEmbed'
+import { useEffect, useMemo, useState } from 'react'
+import { AgentCard, type AgentCardData } from '../components/AgentCard'
+import { AgentDetailsModal } from '../components/AgentDetailsModal'
+import { agentGroups } from '../lib/agents-data'
+import { API_BASE_URL } from '../lib/config'
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api'
+type AgentCategory = keyof typeof agentGroups
 
-// === Tipos base ===
-type AgentSummary = {
+const orderedColumns: AgentCategory[] = ['technical', 'financial', 'regulatory', 'reporting']
+
+type AgentSummary = AgentCardData & {
+  description: string | null
+}
+
+type ApiAgent = {
   id: string
   name: string
   area: string
   description?: string | null
+  type?: string | null
   uses: number
   downloads: number
   rewards: number
   stars: number
   votes: number
-  openaiAgentId?: string | null
-  model?: string | null
-  instructions?: string | null
 }
 
-type AgentMetrics = AgentSummary & { type: AgentType }
-type GroupedAgents = Record<string, AgentMetrics[]>
-<<<<<<< Updated upstream
-=======
-
->>>>>>> Stashed changes
-type AgentTrace = {
-  id: string
-  runId: string
-  status: string
-  grade: number | null
-  evaluator: string | null
-  traceUrl: string | null
-  createdAt: string
-  output?: { role: string; content: string }[] | null
-}
-
-<<<<<<< Updated upstream
-type AgentDetails = AgentMetrics & {
-  description?: string | null
-  updatedAt: string
-  traces?: AgentTrace[]
-=======
-type AgentDetail = {
-  id: string
-  name: string
-  area: string
-  description: string | null
-  updatedAt: string
-  metrics: {
-    uses: number
-    downloads: number
-    rewards: number
-    stars: number
-    votes: number
-  }
-  workflows: {
-    id: string
-    name: string
-    status: string
-    model: string
-    platform: string
-  }[]
->>>>>>> Stashed changes
-}
-
-// === Página principal ===
 export default function Page() {
-  const [agents, setAgents] = useState<AgentMetrics[]>([])
-  const [openId, setOpenId] = useState<string | null>(null)
-  const [selectedDetails, setSelectedDetails] = useState<AgentDetail | null>(null)
-  const [traces, setTraces] = useState<AgentTrace[]>([])
-  const [detailsLoading, setDetailsLoading] = useState(false)
-  const [detailsError, setDetailsError] = useState<string | null>(null)
+  const [agents, setAgents] = useState<AgentSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<AgentCategory | 'all'>('all')
+  const [sortKey, setSortKey] = useState<'stars' | 'uses'>('stars')
+  const [selectedAgent, setSelectedAgent] = useState<AgentSummary | null>(null)
 
   useEffect(() => {
     async function loadAgents() {
       setLoading(true)
       try {
-        const res = await fetch(`${API_BASE_URL}/agents`, { cache: 'no-store' })
-        if (!res.ok) throw new Error('No se pudieron obtener los agentes del ENACOM')
-
-        const data = (await res.json()) as AgentSummary[]
-        const enriched = data.map((agent) => ({
-          ...agent,
-          type: inferAgentType(agent.name)
+        const response = await fetch(`${API_BASE_URL}/agents`, { cache: 'no-store' })
+        if (!response.ok) throw new Error('No se pudieron obtener los agentes registrados')
+        const data = (await response.json()) as ApiAgent[]
+        const mapped = data.map<AgentSummary>((agent) => ({
+          id: agent.id,
+          name: agent.name,
+          area: agent.area,
+          description: agent.description ?? null,
+          type: normalizeCategory(agent.type ?? inferAgentType(agent.name)),
+          uses: agent.uses,
+          downloads: agent.downloads,
+          rewards: agent.rewards,
+          stars: agent.stars,
+          votes: agent.votes
         }))
-        setAgents(enriched)
+        setAgents(mapped)
         setError(null)
       } catch (err) {
         console.error(err)
-        setError(err instanceof Error ? err.message : 'Ocurrió un error al cargar los agentes')
+        setError(err instanceof Error ? err.message : 'Ocurrió un error inesperado al cargar los agentes')
       } finally {
         setLoading(false)
       }
@@ -107,318 +68,136 @@ export default function Page() {
     loadAgents()
   }, [])
 
-  const grouped = useMemo<GroupedAgents>(() => {
-    return agents.reduce<GroupedAgents>((acc, agent) => {
-      if (!acc[agent.type]) acc[agent.type] = []
-      acc[agent.type].push(agent)
-      return acc
-    }, {})
-  }, [agents])
+  const filteredAgents = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase()
+    const list = agents.filter((agent) => {
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        agent.name.toLowerCase().includes(normalizedSearch) ||
+        agent.area.toLowerCase().includes(normalizedSearch)
+      const matchesFilter = filter === 'all' || agent.type === filter
+      return matchesSearch && matchesFilter
+    })
 
-  const selectedAgent = useMemo(() => agents.find((a) => a.id === openId) ?? null, [agents, openId])
-  const selectedAgentId = selectedAgent?.id ?? null
-
-  useEffect(() => {
-    if (!selectedAgentId) {
-      setSelectedDetails(null)
-      setTraces([])
-      return
-    }
-
-    let active = true
-    setDetailsLoading(true)
-    setDetailsError(null)
-
-    async function loadDetails() {
-      try {
-        const [detailsRes, tracesRes] = await Promise.all([
-          fetch(`/api/agents/${selectedAgentId}`, { cache: 'no-store' }),
-          fetch(`/api/agents/${selectedAgentId}/traces?take=10`, { cache: 'no-store' })
-        ])
-
-        if (!detailsRes.ok) throw new Error('No se pudieron obtener los detalles del agente seleccionado')
-
-        const details = (await detailsRes.json()) as AgentDetail
-        const traceData = tracesRes.ok ? ((await tracesRes.json()) as AgentTrace[]) : []
-
-        if (!active) return
-        setSelectedDetails(details)
-        setTraces(traceData)
-      } catch (err) {
-        console.error(err)
-        if (!active) return
-        setDetailsError(err instanceof Error ? err.message : 'Error al obtener detalles del agente')
-      } finally {
-        if (active) setDetailsLoading(false)
+    return [...list].sort((a, b) => {
+      if (sortKey === 'stars') {
+        return b.stars - a.stars
       }
-    }
+      return b.uses - a.uses
+    })
+  }, [agents, filter, search, sortKey])
 
-    loadDetails()
-    return () => {
-      active = false
-    }
-  }, [selectedAgentId])
-
-  const refreshTraces = useCallback(async () => {
-    if (!selectedAgentId) return
-    try {
-      const response = await fetch(`/api/agents/${selectedAgentId}/traces?take=10`, { cache: 'no-store' })
-      if (!response.ok) return
-      const traceData = (await response.json()) as AgentTrace[]
-      setTraces(traceData)
-    } catch (error) {
-      console.error('No se pudieron actualizar las trazas del agente', error)
-    }
-  }, [selectedAgentId])
+  const groupedByCategory = useMemo(() => {
+    return filteredAgents.reduce<Record<AgentCategory, AgentSummary[]>>((acc, agent) => {
+      const category = normalizeCategory(agent.type)
+      if (!acc[category]) {
+        acc[category] = []
+      }
+      acc[category].push(agent)
+      return acc
+    }, { technical: [], financial: [], regulatory: [], reporting: [], risk: [], planning: [], general: [] } as Record<AgentCategory, AgentSummary[]>)
+  }, [filteredAgents])
 
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-semibold text-white/90">Panel de Control ENACOM</h1>
-      <p className="text-white/60 mt-1">
-        Monitoree el uso de los agentes analíticos, informes y reportes estratégicos del Ente Nacional de Comunicaciones.
-      </p>
+    <main className="min-h-screen bg-[#050b15] px-6 pb-16 pt-12 text-white">
+      <div className="mx-auto max-w-7xl">
+        <header className="flex flex-col gap-6 rounded-3xl border border-white/10 bg-gradient-to-br from-slate-900/70 to-slate-950/40 p-8 shadow-2xl">
+          <div className="flex flex-col gap-2">
+            <p className="text-xs uppercase tracking-[0.3em] text-emerald-300/70">Sistema de Agentes Autónomos</p>
+            <h1 className="text-3xl font-semibold text-white/90">Panel de Control ENACOM</h1>
+            <p className="text-sm text-white/60">
+              Monitoree el uso de los agentes analíticos, informes y reportes estratégicos del Ente Nacional de Comunicaciones.
+            </p>
+          </div>
 
-      {error && (
-        <div className="mt-6 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</div>
-      )}
+          <div className="grid gap-4 md:grid-cols-[2fr_1fr_1fr]">
+            <input
+              type="search"
+              placeholder="Buscar agente…"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="w-full rounded-xl border border-white/10 bg-slate-950/60 px-4 py-2.5 text-sm text-white/80 placeholder:text-white/30 focus:border-emerald-400/60 focus:outline-none"
+            />
+            <select
+              value={filter}
+              onChange={(event) => setFilter(event.target.value as AgentCategory | 'all')}
+              className="rounded-xl border border-white/10 bg-slate-950/60 px-4 py-2.5 text-sm text-white/80 focus:border-emerald-400/60 focus:outline-none"
+            >
+              <option value="all">Todas las categorías</option>
+              {orderedColumns.map((key) => (
+                <option key={key} value={key}>
+                  {agentGroups[key].title}
+                </option>
+              ))}
+            </select>
+            <select
+              value={sortKey}
+              onChange={(event) => setSortKey(event.target.value as 'stars' | 'uses')}
+              className="rounded-xl border border-white/10 bg-slate-950/60 px-4 py-2.5 text-sm text-white/80 focus:border-emerald-400/60 focus:outline-none"
+            >
+              <option value="stars">Ordenar por puntuación</option>
+              <option value="uses">Ordenar por usos</option>
+            </select>
+          </div>
+        </header>
 
-      {loading ? (
-        <div className="mt-10 text-white/70">Cargando información de los agentes...</div>
-      ) : (
-        <section className="container-card mt-8">
-          <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
-            {orderedAgentTypes.map((type) => {
-              const metadata = agentGroups[type]
-              const agentsForType = grouped[type] ?? []
-              if (agentsForType.length === 0) return null
+        {error && (
+          <div className="mt-8 rounded-2xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</div>
+        )}
 
+        {loading ? (
+          <div className="mt-16 flex items-center justify-center text-white/60">Cargando información de agentes…</div>
+        ) : (
+          <section className="mt-10 grid gap-6 xl:grid-cols-4">
+            {orderedColumns.map((category) => {
+              const meta = agentGroups[category]
+              const agentsForCategory = groupedByCategory[category] ?? []
               return (
-                <div key={type} className="space-y-3">
-                  <SectionTitle>{metadata.title}</SectionTitle>
-                  <p className="text-xs text-white/50">{metadata.description}</p>
+                <div key={category} className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-slate-950/40 p-6">
+                  <div className="space-y-2">
+                    <p className="text-xs uppercase tracking-[0.25em] text-emerald-300/60">{meta.title}</p>
+                    <p className="text-sm text-white/50">{meta.description}</p>
+                  </div>
                   <div className="space-y-3">
-                    {agentsForType.map((agent) => (
-                      <AgentCard key={agent.id} agent={agent} onOpen={() => setOpenId(agent.id)} />
-                    ))}
+                    {agentsForCategory.length === 0 ? (
+                      <p className="rounded-2xl border border-dashed border-white/10 bg-white/5 px-4 py-6 text-center text-sm text-white/50">
+                        No hay agentes registrados en esta categoría.
+                      </p>
+                    ) : (
+                      agentsForCategory.map((agent) => (
+                        <AgentCard key={agent.id} agent={agent} onDoubleClick={() => setSelectedAgent(agent)} />
+                      ))
+                    )}
                   </div>
                 </div>
               )
             })}
-          </div>
-        </section>
-      )}
-
-      <AgentWorkflowModal
-        agent={selectedAgent}
-        details={selectedDetails}
-        traces={traces}
-        loading={detailsLoading}
-        error={detailsError}
-        onClose={() => setOpenId(null)}
-        onRefreshTraces={refreshTraces}
-      />
-    </div>
-  )
-}
-
-// === Subcomponentes ===
-type WorkflowModalProps = {
-  agent: AgentMetrics | null
-  details: AgentDetail | null
-  traces: AgentTrace[]
-  loading: boolean
-  error: string | null
-  onClose: () => void
-  onRefreshTraces: () => void
-}
-
-function AgentWorkflowModal({ agent, details, traces, loading, error, onClose, onRefreshTraces }: WorkflowModalProps) {
-  useEffect(() => {
-    if (agent) onRefreshTraces()
-  }, [agent?.id, onRefreshTraces])
-
-  return (
-    <AgentModal
-      open={!!agent}
-      onClose={onClose}
-      title={agent ? `${agent.name}` : 'Agente ENACOM'}
-      description={agent?.area ?? undefined}
-    >
-      <div className="space-y-6">
-        {loading && (
-          <div className="rounded-lg border border-white/10 bg-[#0f1a2a] px-4 py-3 text-white/70 text-sm">
-            Cargando información del agente...
-          </div>
-        )}
-
-        {error && (
-          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</div>
-        )}
-
-        {details && (
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="rounded-xl border border-white/10 bg-[#101a29] p-4">
-              <h3 className="text-sm font-semibold text-white/80">Descripción</h3>
-              <p className="text-sm text-white/60 mt-2">
-                {details.description ?? 'Este agente no tiene descripción documentada en la base.'}
-              </p>
-              <p className="text-[11px] text-white/40 mt-3">
-                Última actualización · {new Date(details.updatedAt).toLocaleString()}
-              </p>
-            </div>
-            <div className="rounded-xl border border-white/10 bg-[#101a29] p-4 space-y-3">
-              <h3 className="text-sm font-semibold text-white/80">Integración AgentKit</h3>
-              <InfoRow label="ID OpenAI" value={details.metrics?.uses?.toString() ?? 'No registrado aún'} />
-              <InfoRow label="Modelo" value={details.workflows[0]?.model ?? 'gpt-4.1-mini'} />
-              <InfoRow
-                label="Instrucciones"
-                value={details.description ?? 'Se aplican las instrucciones generadas automáticamente en el backend.'}
-              />
-            </div>
-          </div>
-        )}
-
-        {agent && (
-          <div className="grid md:grid-cols-4 gap-3">
-            <MetricPill label="Usos" value={agent.uses} />
-            <MetricPill label="Descargas" value={agent.downloads} />
-            <MetricPill label="Recompensas" value={agent.rewards} />
-            <MetricPill label="Estrellas" value={`${agent.stars.toFixed(2)} (${agent.votes})`} />
-          </div>
-        )}
-
-        {agent && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-white/80">Chat del agente</h3>
-              <button onClick={onRefreshTraces} className="text-xs text-[#16a34a] hover:text-[#22c55e]">
-                Actualizar trazas
-              </button>
-            </div>
-            <AgentChatKitEmbed
-              agentId={agent.id}
-              agentName={agent.name}
-              onConversationComplete={onRefreshTraces}
-            />
-          </div>
-        )}
-
-        {traces.length > 0 && (
-          <div className="space-y-3">
-            <h3 className="text-sm font-semibold text-white/80">Últimas ejecuciones</h3>
-            <div className="space-y-2 max-h-60 overflow-y-auto pr-1">
-              {traces.map((trace) => (
-                <TraceCard key={trace.id} trace={trace} />
-              ))}
-            </div>
-          </div>
+          </section>
         )}
       </div>
-    </AgentModal>
+
+      <AgentDetailsModal agent={selectedAgent} open={!!selectedAgent} onClose={() => setSelectedAgent(null)} />
+    </main>
   )
 }
 
-function InfoRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <p className="text-[11px] uppercase tracking-wide text-white/40">{label}</p>
-      <p className="text-sm text-white/70 break-words">{value}</p>
-    </div>
-  )
-}
-
-function MetricPill({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="rounded-xl border border-white/10 bg-[#101a29] px-4 py-3">
-      <p className="text-xs text-white/50">{label}</p>
-      <p className="text-lg font-semibold text-white/90">{value}</p>
-    </div>
-  )
-}
-
-function TraceCard({ trace }: { trace: AgentTrace }) {
-  return (
-    <div className="rounded-xl border border-white/10 bg-[#0f1928] p-4 text-sm text-white/80 space-y-2">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2 text-xs text-white/60">
-          <span className="px-2 py-0.5 rounded-full bg-white/10 text-white/70">{trace.status}</span>
-          <span>{new Date(trace.createdAt).toLocaleString()}</span>
-        </div>
-        <div className="text-xs text-white/50">{trace.runId}</div>
-      </div>
-      <div className="text-xs text-white/60">
-        {trace.grade !== null ? `Evaluación automática: ${(trace.grade * 100).toFixed(0)}%` : 'Sin evaluación automática'}
-      </div>
-      <div className="flex flex-wrap gap-2 text-xs text-white/50">
-        {trace.evaluator && <span>{trace.evaluator}</span>}
-        {trace.traceUrl && (
-          <a href={trace.traceUrl} target="_blank" rel="noreferrer" className="text-[#22c55e] hover:underline">
-            Ver traza
-          </a>
-        )}
-      </div>
-      {Array.isArray(trace.output) && trace.output.length > 0 && (
-        <div className="rounded-lg border border-white/5 bg-black/10 p-3 space-y-2">
-          {trace.output.slice(-2).map((message, index) => (
-            <p key={index} className="text-xs text-white/60">
-              <span className="font-semibold text-white/70">{message.role}: </span>
-              {message.content}
-            </p>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-<<<<<<< Updated upstream
-
-const KEYWORD_TYPE_MAP: { keywords: string[]; type: AgentType }[] = [
-  {
-    type: 'technical',
-    keywords: ['técnico', 'tecnico', 'infraestructura', 'radiocomunicaciones', 'tecnología', 'tecnologias']
-  },
-  {
-    type: 'financial',
-    keywords: ['financiero', 'financiera', 'contable', 'presupuesto', 'presupuestaria', 'tesorería', 'tesoreria']
-  },
-  {
-    type: 'regulatory',
-    keywords: ['licencia', 'licencias', 'permiso', 'permisos', 'regulatorio', 'regulatoria', 'normativa', 'expediente']
-  },
-  {
-    type: 'reporting',
-    keywords: ['informe', 'informes', 'reporte', 'reportes', 'tablero', 'dashboard', 'resumen', 'ejecutivo']
-  },
-  {
-    type: 'risk',
-    keywords: ['riesgo', 'riesgos', 'auditoría', 'auditoria', 'alerta']
-  },
-  {
-    type: 'planning',
-    keywords: ['planificación', 'planificacion', 'planificador', 'proyecto', 'proyectos', 'estratégico', 'estrategico', 'planeamiento']
+function normalizeCategory(type: string | null | undefined): AgentCategory {
+  if (!type) return 'general'
+  if (type in agentGroups) {
+    return type as AgentCategory
   }
-]
+  return inferAgentType(type)
+}
 
-function inferAgentType(name: string): AgentType {
-  const normalized = name.toLowerCase()
-
-  for (const { keywords, type } of KEYWORD_TYPE_MAP) {
-    if (keywords.some((keyword) => normalized.includes(keyword))) {
-      return type
-    }
-  }
-=======
-// === Helper para clasificar agentes por tipo ===
-function inferAgentType(name: string): AgentType {
+function inferAgentType(name: string): AgentCategory {
   const normalized = name.toLowerCase()
 
   if (normalized.includes('técnico') || normalized.includes('tecnico')) return 'technical'
   if (normalized.includes('financiero') || normalized.includes('contable')) return 'financial'
   if (normalized.includes('licencia') || normalized.includes('permiso')) return 'regulatory'
   if (normalized.includes('informe') || normalized.includes('reporte')) return 'reporting'
-  if (normalized.includes('riesgo') || normalized.includes('riesgos')) return 'risk'
+  if (normalized.includes('riesgo') || normalized.includes('auditor')) return 'risk'
   if (normalized.includes('planificación') || normalized.includes('proyecto')) return 'planning'
->>>>>>> Stashed changes
 
   return 'general'
 }

--- a/apps/web/src/components/AgentCard.tsx
+++ b/apps/web/src/components/AgentCard.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { memo } from 'react'
+import { Download, Star, Trophy, Zap } from 'lucide-react'
+import clsx from 'clsx'
+import type { AgentType } from '../lib/agents-data'
+
+export type AgentCardData = {
+  id: string
+  name: string
+  area: string
+  description?: string | null
+  type: AgentType
+  uses: number
+  downloads: number
+  rewards: number
+  stars: number
+  votes: number
+}
+
+type AgentCardProps = {
+  agent: AgentCardData
+  onDoubleClick?: (agent: AgentCardData) => void
+}
+
+function AgentCardComponent({ agent, onDoubleClick }: AgentCardProps) {
+  return (
+    <button
+      type="button"
+      onDoubleClick={() => onDoubleClick?.(agent)}
+      className={clsx(
+        'group w-full rounded-2xl border border-white/10 bg-gradient-to-br from-slate-900/80 to-slate-950/80 p-5 text-left shadow-lg transition-transform duration-200 ease-out hover:-translate-y-1 hover:border-emerald-400/60 hover:shadow-emerald-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/80'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-white/90 group-hover:text-emerald-300/90">
+            {agent.name}
+          </h3>
+          <p className="text-xs uppercase tracking-wide text-emerald-300/80">{agent.area}</p>
+        </div>
+        <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-emerald-300">
+          Abrir
+        </span>
+      </div>
+
+      {agent.description && (
+        <p className="mt-3 text-sm text-white/60 line-clamp-3">{agent.description}</p>
+      )}
+
+      <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-white/70">
+        <Metric icon={<Zap className="h-4 w-4" />} label="Usos" value={agent.uses} />
+        <Metric icon={<Download className="h-4 w-4" />} label="Descargas" value={agent.downloads} />
+        <Metric icon={<Trophy className="h-4 w-4" />} label="Recompensas" value={agent.rewards} />
+        <Metric
+          icon={<Star className="h-4 w-4" />}
+          label={`Puntaje • ${agent.votes} votos`}
+          value={agent.stars.toFixed(1)}
+        />
+      </div>
+
+      <p className="mt-4 text-[11px] text-white/40">Haga doble click para ver capacidades y ejecutar acciones.</p>
+    </button>
+  )
+}
+
+function Metric({
+  icon,
+  label,
+  value
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string | number
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-xl border border-white/5 bg-white/5 px-3 py-2">
+      <span className="text-emerald-300/90">{icon}</span>
+      <div>
+        <p className="text-[10px] uppercase tracking-wide text-white/40">{label}</p>
+        <p className="text-sm font-semibold text-white/80">{value}</p>
+      </div>
+    </div>
+  )
+}
+
+export const AgentCard = memo(AgentCardComponent)

--- a/apps/web/src/components/AgentDetailsModal.tsx
+++ b/apps/web/src/components/AgentDetailsModal.tsx
@@ -1,0 +1,420 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Clock, Gauge, Link2, Loader2, Mic, Paperclip, Presentation, RotateCcw, Video, Workflow } from 'lucide-react'
+import AgentModal from './AgentModal'
+import { API_BASE_URL, OPENAI_CAPABILITIES } from '../lib/config'
+import type { AgentCardData } from './AgentCard'
+
+const capabilityPalette = ['bg-sky-500/20 text-sky-200', 'bg-emerald-500/20 text-emerald-200', 'bg-teal-500/20 text-teal-200', 'bg-violet-500/20 text-violet-200']
+
+type AgentDetailResponse = {
+  id: string
+  name: string
+  area: string
+  description: string | null
+  model: string | null
+  openaiAgentId: string | null
+  instructions: string | null
+  updatedAt: string
+  uses?: number
+  downloads?: number
+  rewards?: number
+  votes?: number
+  stars?: number
+}
+
+type AgentMetricsResponse = {
+  accuracy: number | null
+  averageResponseTime: number | null
+  successRate: number | null
+}
+
+type AgentTrace = {
+  id: string
+  status: string
+  createdAt: string
+  evaluator?: string | null
+  grade?: number | null
+  summary?: string | null
+}
+
+type ConversationMessage = {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+type AgentDetailsModalProps = {
+  agent: AgentCardData | null
+  open: boolean
+  onClose: () => void
+}
+
+export function AgentDetailsModal({ agent, open, onClose }: AgentDetailsModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [detail, setDetail] = useState<AgentDetailResponse | null>(null)
+  const [metrics, setMetrics] = useState<AgentMetricsResponse | null>(null)
+  const [traces, setTraces] = useState<AgentTrace[]>([])
+  const [conversation, setConversation] = useState<ConversationMessage[]>([])
+  const [input, setInput] = useState('')
+  const [isRunning, setIsRunning] = useState(false)
+
+  const formattedCapabilities = useMemo(() => OPENAI_CAPABILITIES.map((cap, index) => ({
+    label: cap,
+    className: capabilityPalette[index % capabilityPalette.length]
+  })), [])
+
+  const resetState = useCallback(() => {
+    setDetail(null)
+    setMetrics(null)
+    setTraces([])
+    setConversation([])
+    setInput('')
+    setError(null)
+  }, [])
+
+  const fetchTraces = useCallback(async (agentId: string) => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/agents/${agentId}/traces?take=5`, { cache: 'no-store' })
+      if (!response.ok) return
+      const data = (await response.json()) as AgentTrace[]
+      setTraces(data)
+    } catch (err) {
+      console.error('No se pudieron obtener las trazas del agente', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open || !agent) {
+      resetState()
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const agentId = agent.id
+    async function loadAgent() {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const [detailRes, metricsRes] = await Promise.all([
+          fetch(`${API_BASE_URL}/agents/${agentId}`, { cache: 'no-store' }),
+          fetch(`${API_BASE_URL}/agents/${agentId}/metrics`, { cache: 'no-store' })
+        ])
+
+        if (!detailRes.ok) {
+          throw new Error('No se pudieron obtener los datos del agente seleccionado')
+        }
+
+        const detailData = (await detailRes.json()) as AgentDetailResponse
+        const metricsData = metricsRes.ok ? ((await metricsRes.json()) as AgentMetricsResponse) : null
+
+        if (cancelled) return
+        setDetail(detailData)
+        setMetrics(metricsData)
+        fetchTraces(agentId)
+      } catch (err) {
+        console.error(err)
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'Ocurrió un error al obtener la información del agente')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    loadAgent()
+    return () => {
+      cancelled = true
+    }
+  }, [agent, open, fetchTraces, resetState])
+
+  const handleRun = useCallback(async () => {
+    if (!agent || !input.trim()) return
+
+    const message = input.trim()
+    setConversation((prev) => [...prev, { role: 'user', content: message }])
+    setInput('')
+    setIsRunning(true)
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/agents/${agent.id}/run`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ input: message })
+      })
+
+      if (!response.ok) {
+        const errorMessage = await response.text()
+        throw new Error(errorMessage || 'El agente no pudo completar la solicitud')
+      }
+
+      const raw = await response.text()
+      let content = raw || 'Ejecución completada.'
+      try {
+        const payload = raw ? JSON.parse(raw) : null
+        if (payload) {
+          content =
+            payload.message ||
+            payload.output ||
+            payload.response ||
+            payload.result ||
+            JSON.stringify(payload, null, 2) ||
+            content
+        }
+      } catch {
+        // Mantener contenido sin cambios si no es JSON válido.
+      }
+
+      setConversation((prev) => [...prev, { role: 'assistant', content }])
+      fetchTraces(agent.id)
+    } catch (err) {
+      console.error(err)
+      const message = err instanceof Error ? err.message : 'Ocurrió un error al ejecutar el proceso'
+      setConversation((prev) => [...prev, { role: 'assistant', content: `⚠️ ${message}` }])
+    } finally {
+      setIsRunning(false)
+    }
+  }, [agent, input, fetchTraces])
+
+  const metricsCards = useMemo(() => {
+    if (!metrics) return []
+
+    return [
+      {
+        label: 'Precisión Operativa',
+        value: metrics.accuracy !== null && metrics.accuracy !== undefined ? `${(metrics.accuracy * 100).toFixed(1)}%` : 'N/D',
+        icon: <Gauge className="h-5 w-5" />
+      },
+      {
+        label: 'Tiempo Medio de Respuesta',
+        value:
+          metrics.averageResponseTime !== null && metrics.averageResponseTime !== undefined
+            ? `${metrics.averageResponseTime.toFixed(1)}s`
+            : 'N/D',
+        icon: <Clock className="h-5 w-5" />
+      },
+      {
+        label: 'Tasa de Éxito',
+        value:
+          metrics.successRate !== null && metrics.successRate !== undefined
+            ? `${(metrics.successRate * 100).toFixed(1)}%`
+            : 'N/D',
+        icon: <Presentation className="h-5 w-5" />
+      }
+    ]
+  }, [metrics])
+
+  return (
+    <AgentModal open={open} onClose={onClose} title={agent?.name} description={agent?.area}>
+      <div className="space-y-6 text-white/80">
+        {loading && (
+          <div className="flex items-center gap-3 rounded-xl border border-emerald-400/40 bg-emerald-400/10 px-4 py-3 text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Obteniendo capacidades desde OpenAI Platform…</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        {detail && (
+          <section className="grid gap-4 md:grid-cols-[1.4fr_1fr]">
+            <article className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-5">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-white/50">Descripción General</h3>
+              <p className="text-sm leading-relaxed text-white/70">
+                {detail.description || 'Este agente aún no cuenta con una descripción registrada.'}
+              </p>
+              {agent && (
+                <div className="grid grid-cols-2 gap-3 rounded-2xl border border-white/5 bg-slate-950/40 p-3 text-xs text-white/60 md:grid-cols-4">
+                  <MetricPill label="Usos" value={agent.uses} />
+                  <MetricPill label="Descargas" value={agent.downloads} />
+                  <MetricPill label="Recompensas" value={agent.rewards} />
+                  <MetricPill label="Puntuación" value={`${agent.stars.toFixed(1)} (${agent.votes} votos)`} />
+                </div>
+              )}
+              <div className="grid grid-cols-1 gap-2 text-xs text-white/50 md:grid-cols-2">
+                <InfoRow label="Modelo" value={detail.model ?? 'gpt-4.1-mini'} />
+                <InfoRow label="Agent ID" value={detail.openaiAgentId ?? 'No registrado'} />
+                <InfoRow
+                  label="Actualizado"
+                  value={new Date(detail.updatedAt).toLocaleString('es-AR', {
+                    dateStyle: 'medium',
+                    timeStyle: 'short'
+                  })}
+                />
+                <InfoRow label="Tipo" value={agent?.type ?? 'N/D'} />
+              </div>
+              {detail.instructions && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-white/50">Instrucciones Base</p>
+                  <p className="mt-1 text-sm text-white/65 whitespace-pre-line">{detail.instructions}</p>
+                </div>
+              )}
+            </article>
+
+            <aside className="space-y-4">
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <h4 className="text-sm font-semibold uppercase tracking-wide text-white/50">Capacidades</h4>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {formattedCapabilities.map((capability) => (
+                    <span
+                      key={capability.label}
+                      className={`rounded-full px-3 py-1 text-xs font-medium ${capability.className}`}
+                    >
+                      {capability.label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {metricsCards.length > 0 && (
+                <div className="space-y-2">
+                  {metricsCards.map((metric) => (
+                    <div
+                      key={metric.label}
+                      className="flex items-center justify-between rounded-2xl border border-emerald-400/20 bg-emerald-400/5 px-4 py-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <span className="text-emerald-300/80">{metric.icon}</span>
+                        <p className="text-xs uppercase tracking-wide text-white/50">{metric.label}</p>
+                      </div>
+                      <p className="text-sm font-semibold text-white/80">{metric.value}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </aside>
+          </section>
+        )}
+
+        <section className="space-y-4 rounded-2xl border border-emerald-400/20 bg-emerald-400/5 p-5">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-white/60">Interfaz de Comunicación</h3>
+              <p className="text-xs text-white/50">Interactúe con el agente en tiempo real utilizando ChatKit.</p>
+            </div>
+            <button
+              onClick={() => agent && fetchTraces(agent.id)}
+              className="inline-flex items-center gap-2 rounded-lg border border-emerald-400/30 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-300/60 hover:text-emerald-100"
+              type="button"
+            >
+              <RotateCcw className="h-4 w-4" />
+              Actualizar registros
+            </button>
+          </header>
+
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+            {conversation.length === 0 && (
+              <p className="text-sm text-white/50">
+                Envíe una instrucción para iniciar la conversación con el agente autónomo.
+              </p>
+            )}
+            {conversation.map((message, index) => (
+              <div
+                key={`${message.role}-${index}`}
+                className={`rounded-xl border px-3 py-2 text-sm shadow-sm ${
+                  message.role === 'user'
+                    ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100'
+                    : 'border-white/10 bg-white/5 text-white/70'
+                }`}
+              >
+                <p className="text-[11px] uppercase tracking-wider text-white/40">
+                  {message.role === 'user' ? 'Operador' : 'Agente ENACOM'}
+                </p>
+                <p className="mt-1 whitespace-pre-line">{message.content}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-3">
+            <textarea
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="Ingrese su consulta o instrucciones…"
+              rows={3}
+              className="w-full rounded-xl border border-white/10 bg-slate-950/60 p-3 text-sm text-white/80 placeholder:text-white/30 focus:border-emerald-400/70 focus:outline-none"
+            />
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-wrap gap-2 text-xs">
+                <ActionChip icon={<Paperclip className="h-4 w-4" />} label="Adjuntar Archivo" />
+                <ActionChip icon={<Mic className="h-4 w-4" />} label="Entrada de Voz" />
+                <ActionChip icon={<Video className="h-4 w-4" />} label="Adjuntar Video" />
+                <ActionChip icon={<Link2 className="h-4 w-4" />} label="Adjuntar Enlace" />
+              </div>
+              <button
+                type="button"
+                disabled={isRunning || !input.trim()}
+                onClick={handleRun}
+                className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-500/40"
+              >
+                {isRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <Workflow className="h-4 w-4" />}
+                Ejecutar Proceso
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {traces.length > 0 && (
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-white/60">Últimas ejecuciones</h3>
+            <div className="grid gap-3">
+              {traces.map((trace) => (
+                <div key={trace.id} className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-white/50">
+                    <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[10px] uppercase tracking-wider">
+                      {trace.status}
+                    </span>
+                    <span>{new Date(trace.createdAt).toLocaleString()}</span>
+                  </div>
+                  {trace.summary && <p className="mt-2 text-white/70">{trace.summary}</p>}
+                  <div className="mt-2 text-[11px] text-white/40">
+                    {trace.grade !== null && trace.grade !== undefined
+                      ? `Evaluación • ${(trace.grade * 100).toFixed(0)}%`
+                      : 'Sin evaluación automática registrada'}
+                  </div>
+                  {trace.evaluator && (
+                    <p className="text-[11px] text-white/40">Evaluador: {trace.evaluator}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </AgentModal>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[10px] uppercase tracking-wide text-white/40">{label}</p>
+      <p className="text-sm text-white/70">{value}</p>
+    </div>
+  )
+}
+
+function ActionChip({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] font-medium text-white/60">
+      <span className="text-emerald-300/80">{icon}</span>
+      {label}
+    </span>
+  )
+}
+
+function MetricPill({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <p className="text-[10px] uppercase tracking-wide text-white/40">{label}</p>
+      <p className="mt-1 text-sm font-semibold text-white/70">{value}</p>
+    </div>
+  )
+}

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -1,0 +1,10 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api'
+
+export const OPENAI_CAPABILITIES = [
+  'Análisis Avanzado',
+  'Automatización',
+  'Procesamiento de Datos',
+  'Integración API',
+  'Visualización',
+  'Generación de Reportes'
+] as const


### PR DESCRIPTION
## Summary
- create a four-column agents dashboard with search, filtering, and sorting backed by the local API
- add dedicated components for agent cards, modal details, and shared configuration helpers
- implement an interactive modal that surfaces OpenAI capabilities, metrics, conversation controls, and trace history

## Testing
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68e70f851dc8832585f948be030f39ab