### PR TITLE
Fix agent type handling for hidden categories

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -23,6 +23,7 @@ type AgentSummary = {
   openaiAgentId?: string | null
   model?: string | null
   instructions?: string | null
+  type?: AgentType
 }
 
 type AgentMetrics = AgentSummary & { type: AgentType }
@@ -81,7 +82,7 @@ export default function Page() {
         const data = (await res.json()) as AgentSummary[]
         const enriched = data.map((agent) => ({
           ...agent,
-          type: inferAgentType(agent.name)
+          type: agent.type ?? inferAgentType(agent.name)
         }))
         setAgents(enriched)
         setError(null)
@@ -390,11 +391,11 @@ const KEYWORD_TYPE_MAP: { keywords: string[]; type: AgentType }[] = [
 function inferAgentType(name: string): AgentType {
   const normalized = name.toLowerCase()
 
-  if (normalized.includes('técnico') || normalized.includes('tecnico')) return 'technical'
-  if (normalized.includes('financiero') || normalized.includes('contable')) return 'financial'
-  if (normalized.includes('licencia') || normalized.includes('permiso')) return 'regulatory'
-  if (normalized.includes('informe') || normalized.includes('reporte')) return 'reporting'
+  for (const { keywords, type } of KEYWORD_TYPE_MAP) {
+    if (keywords.some((keyword) => normalized.includes(keyword))) {
+      return type
+    }
+  }
 
-  // 👇 Agregar este return por defecto
-  return 'technical'
+  return 'general'
 }


### PR DESCRIPTION
## Summary
- use backend-provided agent type when available and only infer locally as a fallback
- expand local inference to cover every agent category and default to the general bucket

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e7147f2fdc83259cb5e1a2779e5369