### PR TITLE
Adjust dashboard leaderboard fetch URL

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -27,6 +27,15 @@ type LeaderboardResponse = {
   areas: AreaSummary[]
 }
 
+const DASHBOARD_BASE_URL =
+  process.env.NEXT_PUBLIC_ENACOM_API_URL ??
+  process.env.NEXT_PUBLIC_API_URL?.replace(/\/?api\/?$/, '') ??
+  ''
+
+const DASHBOARD_LEADERBOARD_ENDPOINT = DASHBOARD_BASE_URL
+  ? `${DASHBOARD_BASE_URL.replace(/\/$/, '')}/dashboard/leaderboard`
+  : '/dashboard/leaderboard'
+
 export default function DashboardPage() {
   const [data, setData] = useState<LeaderboardResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -35,7 +44,7 @@ export default function DashboardPage() {
   useEffect(() => {
     async function fetchLeaderboard() {
       try {
-        const res = await fetch('http://localhost:3001/dashboard/leaderboard')
+        const res = await fetch(DASHBOARD_LEADERBOARD_ENDPOINT)
         if (!res.ok) throw new Error('Error al obtener el ranking de agentes')
         const json = (await res.json()) as LeaderboardResponse
         setData(json)


### PR DESCRIPTION
## Summary
- replace the dashboard leaderboard fetch with a configurable endpoint derived from public environment variables
- default to a relative path when no API base URL is configured to keep local development working

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e719931e8483258490b8c280d12fc2