### PR TITLE
Fix dashboard leaderboard fallback URL

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from 'react'
 
+import { API_BASE_URL } from '../../lib/config'
+
 type AgentRanking = {
   id: string
   name: string
@@ -29,12 +31,13 @@ type LeaderboardResponse = {
 
 const DASHBOARD_BASE_URL =
   process.env.NEXT_PUBLIC_ENACOM_API_URL ??
-  process.env.NEXT_PUBLIC_API_URL?.replace(/\/?api\/?$/, '') ??
-  ''
+  process.env.NEXT_PUBLIC_API_URL ??
+  process.env.NEXT_PUBLIC_API_ROOT ??
+  undefined
 
-const DASHBOARD_LEADERBOARD_ENDPOINT = DASHBOARD_BASE_URL
-  ? `${DASHBOARD_BASE_URL.replace(/\/$/, '')}/dashboard/leaderboard`
-  : '/dashboard/leaderboard'
+const DASHBOARD_API_ROOT = (DASHBOARD_BASE_URL ?? API_BASE_URL).replace(/\/$/, '')
+
+const DASHBOARD_LEADERBOARD_ENDPOINT = `${DASHBOARD_API_ROOT}/dashboard/leaderboard`
 
 export default function DashboardPage() {
   const [data, setData] = useState<LeaderboardResponse | null>(null)


### PR DESCRIPTION
## Summary
- replace the dashboard leaderboard fetch with a configurable endpoint derived from public environment variables
- default the dashboard leaderboard request to the shared API base URL so local development works without extra env configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7254704e4832582172c5a4529a225