### PR TITLE
fix: ensure dashboard fetch uses api prefix

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -35,7 +35,7 @@ export default function DashboardPage() {
   useEffect(() => {
     async function fetchLeaderboard() {
       try {
-        const res = await fetch('http://localhost:3001/dashboard/leaderboard')
+        const res = await fetch('/api/dashboard/leaderboard')
         if (!res.ok) throw new Error('Error al obtener el ranking de agentes')
         const json = (await res.json()) as LeaderboardResponse
         setData(json)


### PR DESCRIPTION
## Summary
- add a dashboard module that exposes a /dashboard/leaderboard endpoint with agent and area aggregations
- register the dashboard module in the NestJS app
- build a dashboard page that consumes the leaderboard API and displays ranking and area metrics
- fix the dashboard page fetch to call the /api-prefixed leaderboard endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e72543cbf483259053861a133926f3