### PR TITLE
fix: route agent run endpoints through new controller

### DIFF
--- a/apps/api/src/agents/agent-run.controller.ts
+++ b/apps/api/src/agents/agent-run.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import OpenAI from 'openai';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -48,11 +48,14 @@ export class AgentRunController {
   }
 
   @Get('traces')
-  async listTraces(@Param('id') id: string) {
+  async listTraces(@Param('id') id: string, @Query('take') take?: string) {
+    const parsed = take ? Number.parseInt(take, 10) : NaN;
+    const amount = Number.isNaN(parsed) ? 20 : parsed;
+
     const traces = await this.prisma.agentTrace.findMany({
       where: { agentId: id },
       orderBy: { createdAt: 'desc' },
-      take: 10,
+      take: amount,
     });
 
     return traces;

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common'
-import { AgentRunnerService, AgentRunPayload } from './agent-runner.service'
+import { Controller, Get, Param, Post } from '@nestjs/common'
+import { AgentRunnerService } from './agent-runner.service'
 import { AgentsService } from './agents.service'
 
 @Controller('agents')
@@ -14,18 +14,6 @@ export class AgentsController {
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.agentsService.getAgent(id)
-  }
-
-  @Get(':id/traces')
-  listTraces(@Param('id') id: string, @Query('take') take?: string) {
-    const parsed = take ? Number.parseInt(take, 10) : NaN
-    const amount = Number.isNaN(parsed) ? undefined : parsed
-    return this.runnerService.listTraces(id, amount)
-  }
-
-  @Post(':id/run')
-  runAgent(@Param('id') id: string, @Body() payload: AgentRunPayload) {
-    return this.runnerService.run(id, payload)
   }
 
   @Post(':id/chat-session')


### PR DESCRIPTION
## Summary
- remove the run and trace endpoints from `AgentsController` so the new logic is used
- allow the `AgentRunController` trace listing to accept an optional `take` parameter with a sensible default

## Testing
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68e72542aa4483259723d0e23cde9894