### PR TITLE
feat: add automatic evaluation of agent traces

### DIFF
--- a/apps/api/prisma/migrations/20251008190000_add_agent_trace_feedback_column/migration.sql
+++ b/apps/api/prisma/migrations/20251008190000_add_agent_trace_feedback_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AgentTrace" ADD COLUMN "feedback" TEXT;


### PR DESCRIPTION
## Summary
- add an AgentEvalService that calls OpenAI to grade agent traces and store evaluator feedback
- trigger the auto-evaluation after completing runs and expose the new service through the agents module
- extend the AgentTrace Prisma model/service to persist feedback data alongside grades
- add a Prisma migration to create the AgentTrace.feedback column

## Testing
- not run (DATABASE_URL not configured in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e725426f8483258b9d682edbc012d0