### PR TITLE
fix: restore agent category coverage

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,12 +3,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import { AgentCard, type AgentCardData } from '../components/AgentCard'
 import { AgentDetailsModal } from '../components/AgentDetailsModal'
-import { agentGroups } from '../lib/agents-data'
+import { agentGroups, orderedAgentTypes } from '../lib/agents-data'
 import { API_BASE_URL } from '../lib/config'
 
 type AgentCategory = keyof typeof agentGroups
 
-const orderedColumns: AgentCategory[] = ['technical', 'financial', 'regulatory', 'reporting']
+const orderedColumns: AgentCategory[] = orderedAgentTypes
 
 type AgentSummary = AgentCardData & {
   description: string | null


### PR DESCRIPTION
## Summary
- include the shared ordered agent type list so every category renders in the dashboard filters and columns

## Testing
- `CI=1 pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68e7253f80808325a248dcdb3c4d845d