### PR TITLE
Add technical diagnosis report

### DIFF
--- a/reports/diagnostico-tecnico.md
+++ b/reports/diagnostico-tecnico.md
@@ -1,0 +1,237 @@
+**Summary**
+* El backend solo declara `AgentsModule` y `DashboardModule`, con controladores para listados, métricas y dashboard, pero la ausencia total de `PrismaService` (importado en todos los servicios) impide compilar y deja sin registrar rutas críticas como `POST /agents/:id/run` que la UI requiere. 
+
+
+
+
+
+
+* El esquema Prisma define `Agent`, `AgentUsage`, `AgentTrace` y `Workflow`, pero apunta a `file:../prisma/dev.db` y no existe carpeta de migraciones; esto dificulta reproducir el estado de la base y alinear el campo `type` (string libre) con los tipos usados en el frontend. 
+
+
+
+* El frontend Next.js consume `GET /api/agents`, `POST /api/agents/:id/run`, `GET /api/dashboard/leaderboard` y `GET http://localhost:3001/dashboard/areas`; estas dos últimas rutas no existen o ignoran el prefijo `/api`, y la UI espera métricas (accuracy/response time) que el backend no devuelve. 
+
+
+
+
+
+
+
+* La integración con OpenAI está parcialmente implementada en `AgentRunnerService`, `AgentEvalService` y `AgentRunController`, pero la falta de `PrismaService` y de endpoints registrados bloquea su uso; además el frontend usa ChatKit mediante rutas proxy en Next. 
+
+
+
+
+* Solo existen dos suites de pruebas (una e2e y una de UI), y `pnpm test` falla por la importación inexistente de `PrismaService`. 
+
+
+
+
+
+**Testing**
+* ❌ `pnpm -C apps/api build` 
+
+
+* ❌ `pnpm test` 
+
+
+
+# Diagnóstico técnico del repositorio
+## 1. Backend (NestJS)
+- Módulos detectados:
+  - `AgentsModule` (controladores de agentes y métricas, servicios de agentes, métricas, runner, trazas y evaluación). 
+
+
+  - `DashboardModule` (agrega `DashboardController`). 
+
+
+- Endpoints activos:
+  - `GET /api/agents`, `GET /api/agents/:id`, `POST /api/agents/:id/chat-session`. 
+
+
+  - `GET /api/agents/:id/metrics`, `POST /api/agents/:id/{use|download|reward|rate}` (comparten `@Controller('agents/:id')`). 
+
+
+  - `GET /api/dashboard/areas`. 
+
+
+- Problemas detectados:
+  - Falta la clase `PrismaService` en `src/prisma`, lo que provoca errores de compilación y bloquea todas las rutas que dependen de base de datos. 
+
+
+  - `AgentRunController` no se registra en `AgentsModule`, por lo que `POST /api/agents/:id/run` y `GET /api/agents/:id/traces` nunca se exponen aunque la UI y los proxies los llamen. 
+
+
+
+  - `MetricsController` y `AgentRunController` usan `@Controller('agents/:id')`, un patrón inusual que dificulta compartir prefijo y puede generar conflictos con otras rutas. 
+
+
+
+  - No hay validaciones ni DTOs; todo llega como `any`, incluida la ejecución de herramientas desde OpenAI.
+- Recomendaciones:
+  - Implementar `PrismaService` (extiende `PrismaClient`, gestiona lifecycle) y añadirlo a un `DatabaseModule` reutilizable.
+  - Registrar `AgentRunController` en `AgentsModule` y/o mover sus rutas al propio `AgentsController` para alinearlas con las expectativas del frontend.
+  - Sustituir prefijos parametrizados en `@Controller` por rutas normales (`@Controller('agents')` + `@Post(':id/run')`).
+  - Añadir DTOs/validaciones (`class-validator`) para los cuerpos de `rate`, `run`, etc., y capturar errores de OpenAI con `try/catch` centralizado.
+
+## 2. Frontend (Next.js)
+- Páginas:
+  - `src/app/page.tsx`: listado de agentes, filtros y modal de detalle. 
+
+
+  - `src/app/dashboard/page.tsx`: tablero de métricas globales (requiere `/api/dashboard/leaderboard`). 
+
+
+  - `src/app/dashboard/areas/page.tsx`: gráficos por área llamando a `http://localhost:3001/dashboard/areas`. 
+
+
+- Componentes principales:
+  - `AgentDetailsModal` (detalle, métricas avanzadas, ejecución y trazas). 
+
+
+  - `AgentChatKitEmbed` (monta ChatKit o fallback local, depende de `/api/agents/:id/chat-session` y `/api/agents/:id/run`). 
+
+
+  - `AgentCard` (grid principal con métricas). 
+
+
+- Problemas detectados:
+  - `/dashboard/areas` ignora el prefijo `/api` configurado en Nest (`app.setGlobalPrefix('api')`), por lo que recibirá 404 si se usa la API real. 
+
+
+
+  - `/api/dashboard/leaderboard` no existe en el backend; la página quedará con error permanente. 
+
+
+
+  - El modal espera métricas avanzadas (`accuracy`, `averageResponseTime`, `successRate`) que el backend nunca devuelve (solo `uses`, `downloads`, etc.). 
+
+
+
+  - El fallback de ChatKit llama a `/api/agents/:id` (POST) → backend `/agents/:id/run`, ruta actualmente inexistente. 
+
+
+- Recomendaciones:
+  - Centralizar las URLs en `API_BASE_URL` y reutilizar `forwardToEnacom` también para dashboard, evitando hardcodes (`http://localhost:3001`).
+  - Crear (o adaptar) endpoints en el backend que devuelvan la estructura esperada por el dashboard y las métricas avanzadas, o bien ajustar la UI a lo que existe.
+  - Manejar estados de error en UI (por ejemplo, mostrar mensaje si `metrics` es `null`).
+  - Añadir pruebas para la página principal y el modal, incluyendo simulación de errores de red.
+
+## 3. Base de datos
+- Modelos y relaciones:
+  - `Agent` (relaciones 1‑N con `AgentUsage`, `AgentTrace`, `Workflow`). 
+
+
+  - `AgentUsage` (FK `agentId`, cascade, índice). 
+
+
+  - `AgentTrace` (FK `agentId`, campos `runId`, `status`, `grade`, `feedback`). 
+
+
+  - `Workflow` (FK `agentId`, campos `status`, `model`, `platform`). 
+
+
+- Inconsistencias:
+  - `datasource` apunta a `file:../prisma/dev.db`; ejecutado desde `apps/api` creará `apps/prisma/dev.db`, distinto del seed (`file:./dev.db` esperado). 
+
+
+  - No hay `prisma/migrations`, por lo que no se puede verificar estado ni reproducir el esquema en otros entornos. 
+
+
+  - Campo `Agent.type` es un `String` libre (`default "Analyst"`), pero los servicios/Front lo calculan como categorías específicas; conviene transformarlo en `enum` o sincronizar. 
+
+
+
+- Recomendaciones:
+  - Normalizar `datasource` a `file:./dev.db` (o usar `DATABASE_URL`) y generar migraciones (`prisma migrate dev`).
+  - Introducir enums (`@default`) o tablas de referencia para `action`, `status` y `type`.
+  - Aprovechar `Workflow` o eliminarlo si no se usa, para evitar deuda de esquema.
+
+## 4. OpenAI SDK Integration
+- Servicios involucrados:
+  - `AgentRunnerService`: gestiona registro en Agent Builder, ejecuta `responses.create`, maneja tool-calls (`registrar_uso`, etc.) y guarda trazas/evaluaciones. 
+
+
+  - `AgentEvalService`: corre una autoevaluación con `chat.completions.create`. 
+
+
+  - `AgentRunController`: invoca `agents.runs.create` y guarda trazas rápidas. 
+
+
+  - Frontend ChatKit: `AgentChatKitEmbed` crea sesiones (`/api/agents/:id/chat-session`) o usa fallback local. 
+
+
+- Problemas detectados:
+  - Falta de `PrismaService` impide registrar trazas y rompe los servicios anteriores. 
+
+
+  - `AgentRunnerService` depende de métodos (`agents.create`, `responses.submitToolOutputs`) que podrían no existir en `openai@6.2.0` si no se configura `openai-agents`; se maneja con `ServiceUnavailableException`, pero conviene validar versiones.
+  - `AgentEvalService` instancia `OpenAI` incluso sin API key (aunque devuelve pronto); podría aplazarse hasta ejecutar la evaluación.
+- Recomendaciones:
+  - Añadir comprobaciones de feature flags (p. ej. verificar `client.responses`) antes de procesar tool-calls.
+  - Consolidar la lógica de ejecución: decidir entre `AgentRunController` (legacy) y `AgentRunnerService` (AgentKit) para evitar duplicaciones.
+  - Registrar métricas y trazas directamente desde el runner y devolver un objeto consistente para el frontend (transcript, evaluación, URL, etc.).
+
+## 5. Testing
+- Archivos de prueba:
+  - `apps/api/test/dashboard.e2e-spec.ts` (único e2e, mockea Prisma). 
+
+
+  - `apps/web/src/app/dashboard/areas/page.test.tsx` (test de render básico). 
+
+
+- Cobertura:
+  - Backend: solo se prueba el endpoint de áreas; el resto de módulos queda sin cobertura.
+  - Frontend: únicamente la página de áreas; ni la home ni el modal tienen tests.
+- Estado de ejecución:
+  - `pnpm test` falla por la importación inexistente de `PrismaService` en los tests del backend. 
+
+
+- Recomendaciones:
+  - Crear `PrismaService` mockeable y usar providers fake en todos los tests.
+  - Añadir pruebas de integración para `AgentsController`, `MetricsController` y `AgentRunnerService` (simulando OpenAI con mocks).
+  - Extender Jest/Testing Library para la UI principal, incluyendo casos de error 404/503.
+
+## 6. Conclusiones y siguientes pasos
+- Estado actual:
+  - **API**: arquitectura modular clara pero incompleta; imposible compilar por falta de `PrismaService` y endpoints clave sin registrar.
+  - **Frontend**: diseño modular y estilizado, pero depende de rutas inexistentes y métricas no disponibles.
+  - **BD**: esquema definido pero sin migraciones ni servicio de acceso; semillas potencialmente apuntan a una ruta diferente.
+  - **OpenAI**: lógica avanzada presente (registro automático, herramientas, evaluaciones), aunque inoperativa hasta resolver Prisma y endpoints.
+  - **Tests**: cobertura mínima; la suite falla.
+- Errores críticos:
+  - Compilación TypeScript rota (`PrismaService` faltante). 
+
+
+  - Tests fallidos por la misma causa. 
+
+
+  - Rutas consumidas por la UI sin implementación (`/dashboard/leaderboard`, `/agents/:id/run`, `/dashboard/areas` sin prefijo).
+- Fortalezas:
+  - Separación clara de capas (servicios de métricas, trazas, evals) y uso consistente de NestJS. 
+
+
+
+  - Integración con OpenAI AgentKit bien estructurada (manejo de tool-calls, trazas y evaluaciones). 
+
+
+  - Frontend con componentes reutilizables y proxies (`forwardToEnacom`) para desacoplar rutas. 
+
+
+
+- Sugerencias de mejora:
+  - Implementar `PrismaService`, generar migraciones y crear seeds consistentes.
+  - Alinear endpoints backend/frontend: añadir `GET /api/dashboard/leaderboard`, exponer `POST /api/agents/:id/run` y ajustar URLs del frontend para respetar el prefijo `/api`.
+  - Devolver métricas avanzadas (o ajustar la UI) y considerar normalizar el campo `type` en Prisma.
+  - Consolidar la integración OpenAI en un único flujo (`AgentRunnerService`) y documentar las dependencias (`openai`, `openai-agents`).
+  - Ampliar la suite de pruebas (mock de Prisma y de OpenAI) y habilitar linters/formateadores reales (`lint` hoy solo imprime un mensaje). 
+
+
+  - Revisar dependencias duplicadas (por ejemplo, dos versiones de `framer-motion` en web y UI). 
+
+
+
+
+En resumen, el repositorio contiene la estructura necesaria para una plataforma de agentes, pero requiere completar las piezas fundamentales (servicio de base de datos, endpoints coherentes, migraciones y pruebas) antes de ser utilizable.
+


### PR DESCRIPTION
## Summary
- add markdown report capturing the prior technical audit findings for backend, frontend, database, OpenAI, and testing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7357629588325b4140a732763cc05