### PR TITLE
fix: proxy dashboard leaderboard to backend

### DIFF
--- a/apps/web/src/app/api/dashboard/leaderboard/route.ts
+++ b/apps/web/src/app/api/dashboard/leaderboard/route.ts
@@ -1,0 +1,5 @@
+import { forwardToEnacom } from '../../agents/_utils'
+
+export async function GET() {
+  return forwardToEnacom('/dashboard/leaderboard')
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -35,7 +35,7 @@ export default function DashboardPage() {
   useEffect(() => {
     async function fetchLeaderboard() {
       try {
-        const res = await fetch('/api/dashboard/leaderboard')
+        const res = await fetch('/api/dashboard/leaderboard', { cache: 'no-store' })
         if (!res.ok) throw new Error('Error al obtener el ranking de agentes')
         const json = (await res.json()) as LeaderboardResponse
         setData(json)


### PR DESCRIPTION
## Summary
- add a dashboard module that exposes a /dashboard/leaderboard endpoint with agent and area aggregations
- register the dashboard module in the NestJS app
- build a dashboard page that consumes the leaderboard API and displays ranking and area metrics
- expose a Next.js API proxy so the dashboard fetch can call the /api-prefixed leaderboard endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7394462c8832586a5919ebd32cf44