### PR TITLE
fix: route agent run endpoints through new controller

### DIFF
--- a/apps/api/src/agents/agent-run.controller.ts
+++ b/apps/api/src/agents/agent-run.controller.ts
@@ -1,50 +1,22 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
-import OpenAI from 'openai';
-import { PrismaService } from '../prisma/prisma.service';
+import { AgentRunnerService } from './agent-runner.service';
 
 @Controller('agents/:id')
 export class AgentRunController {
-  private readonly openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly runnerService: AgentRunnerService) {}
 
   @Post('run')
   async runAgent(
     @Param('id') id: string,
-    @Body() body: { input?: string }
+    @Body() body: Parameters<AgentRunnerService['run']>[1]
   ) {
-    const agent = await this.prisma.agent.findUnique({ where: { id } });
-    if (!agent || !agent.openaiAgentId) {
-      return { error: 'Agente no encontrado o sin ID de OpenAI' };
+    const payload = { ...(body ?? {}) } as Parameters<AgentRunnerService['run']>[1];
+
+    if (!payload.input && (!payload.messages || payload.messages.length === 0)) {
+      payload.input = 'Ejecutar análisis predeterminado';
     }
 
-    try {
-      const agentsApi = (this.openai as any).agents;
-      const run = await agentsApi.runs.create({
-        agent_id: agent.openaiAgentId,
-        input: body?.input ?? 'Ejecutar análisis predeterminado',
-      });
-
-      const trace = await this.prisma.agentTrace.create({
-        data: {
-          agentId: id,
-          runId: run.id,
-          status: run.status,
-          grade: null,
-          evaluator: 'auto',
-          traceUrl: `https://platform.openai.com/agents/${agent.openaiAgentId}/runs/${run.id}`,
-          input: body?.input ?? null,
-          output: JSON.stringify(run.output ?? []),
-        },
-      });
-
-      return { ok: true, run, trace };
-    } catch (err) {
-      const error = err as Error;
-      // eslint-disable-next-line no-console
-      console.error('❌ Error ejecutando agente:', error.message);
-      return { error: error.message };
-    }
+    return this.runnerService.run(id, payload);
   }
 
   @Get('traces')
@@ -52,12 +24,6 @@ export class AgentRunController {
     const parsed = take ? Number.parseInt(take, 10) : NaN;
     const amount = Number.isNaN(parsed) ? 20 : parsed;
 
-    const traces = await this.prisma.agentTrace.findMany({
-      where: { agentId: id },
-      orderBy: { createdAt: 'desc' },
-      take: amount,
-    });
-
-    return traces;
+    return this.runnerService.listTraces(id, amount);
   }
 }


### PR DESCRIPTION
## Summary
- remove the run and trace endpoints from `AgentsController` so the new logic is used
- allow the `AgentRunController` trace listing to accept an optional `take` parameter with a sensible default
- delegate the run endpoint in `AgentRunController` to `AgentRunnerService` so agents still auto-register before executing

## Testing
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68e7394223448325adedd2613db1262b