### PR TITLE
fix(api): restore agents controller responses

### DIFF
--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -8,12 +8,12 @@ export class AgentsController {
 
   @Get()
   getAll() {
-    return this.agentsService.findAll()
+    return this.agentsService.listAgents()
   }
 
   @Get(':id')
   getById(@Param('id') id: string) {
-    return this.agentsService.findOne(id)
+    return this.agentsService.getAgent(id)
   }
 
   @Post()


### PR DESCRIPTION
## Summary
- revert the GET /agents endpoint to use listAgents so the lightweight summary shape and ordering remain intact
- route GET /agents/:id through getAgent to continue throwing a 404 for missing records

## Testing
- pnpm test agents --filter @agentic-platform/api *(fails: No projects matched the filters in "/workspace/agentic-platform")*

------
https://chatgpt.com/codex/tasks/task_e_68e7393c37ac8325b9239264844392a2