### PR TITLE
Add regulatory and reporting agents to seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ La integración permite:
 2. Chateá desde el componente ChatKit (o fallback) y pide acciones como “descargar informe”.
 3. Las herramientas configuradas llamarán a los endpoints del backend para registrar cada acción.
 4. Revisa el apartado “Últimas ejecuciones” para ver la traza, la calificación y acceder al enlace externo de seguimiento (`traceUrl`) si está disponible.
+
+## Base de datos y seed
+
+- Para regenerar la base de datos con los agentes demo ejecutá:
+
+  ```bash
+  pnpm -C apps/api prisma db seed
+  ```
+
+- El script `apps/api/prisma/seed.ts` crea agentes con métricas iniciales para la demo del dashboard.

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -18,6 +18,26 @@ async function main() {
         name: 'Analista de Licencias',
         description: 'Controla los permisos y autorizaciones',
         area: 'Gestión de licencias'
+      },
+      {
+        name: 'Gestión Regulatoria',
+        description: 'Monitorea el cumplimiento normativo y los procesos de licenciamiento TIC.',
+        area: 'Gestión Regulatoria y Licencias',
+        uses: 58,
+        downloads: 24,
+        rewards: 6,
+        stars: 4.3,
+        votes: 42
+      },
+      {
+        name: 'Reportes e Informes',
+        description: 'Genera tableros ejecutivos y reportes institucionales automatizados.',
+        area: 'Reportes e Informes Institucionales',
+        uses: 87,
+        downloads: 33,
+        rewards: 11,
+        stars: 4.6,
+        votes: 73
       }
     ]
   });


### PR DESCRIPTION
## Summary
- add demo seed entries for Gestión Regulatoria and Reportes e Informes with initial metrics
- document how to rerun the Prisma seed for developers in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e73e5286048325832b35335d700db4