### PR TITLE
Limit agent categories to core groups

### DIFF
--- a/apps/web/src/lib/agents-data.ts
+++ b/apps/web/src/lib/agents-data.ts
@@ -1,11 +1,4 @@
-export type AgentType =
-  | 'technical'
-  | 'financial'
-  | 'regulatory'
-  | 'reporting'
-  | 'risk'
-  | 'planning'
-  | 'general'
+export type AgentType = 'technical' | 'financial' | 'regulatory' | 'reporting'
 
 export const agentGroups: Record<AgentType, { title: string; description: string }> = {
   technical: {
@@ -27,21 +20,6 @@ export const agentGroups: Record<AgentType, { title: string; description: string
     title: 'Reportes e Informes Institucionales',
     description:
       'Documentos ejecutivos y tableros que consolidan hallazgos regulatorios, técnicos y financieros para la gestión pública.'
-  },
-  risk: {
-    title: 'Gestión de Riesgos y Control',
-    description:
-      'Herramientas que monitorean riesgos operativos, alertas tempranas y mecanismos de control interno del ENACOM.'
-  },
-  planning: {
-    title: 'Planificación y Proyectos Estratégicos',
-    description:
-      'Agentes que coordinan la planificación, seguimiento de proyectos y evaluación de impacto de las iniciativas institucionales.'
-  },
-  general: {
-    title: 'Agentes Institucionales Generales',
-    description:
-      'Asistentes transversales que brindan soporte integral para diversas áreas y necesidades del organismo.'
   }
 }
 
@@ -49,8 +27,5 @@ export const orderedAgentTypes: AgentType[] = [
   'technical',
   'financial',
   'regulatory',
-  'reporting',
-  'risk',
-  'planning',
-  'general'
+  'reporting'
 ]


### PR DESCRIPTION
## Summary
- restrict the agent type data to the four primary categories used in the UI
- keep the ordered agent list aligned with the grid columns

## Testing
- pnpm --filter web dev

------
https://chatgpt.com/codex/tasks/task_e_68e73e7552b08325a82e46218a6dbe36