### PR TITLE
Add Jest test script for web app

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "jest --config jest.config.ts",
     "clean": "rimraf node_modules apps/*/node_modules packages/*/node_modules pnpm-lock.yaml .turbo"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a dedicated Jest test script to the web package for easier execution under pnpm

## Testing
- pnpm -C apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68e73ea4e82083259d2a3f3d445c8b87