### PR TITLE
Add backend Day 1 scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ La integración permite:
    | `NEXT_PUBLIC_ENACOM_API_URL` | URL del backend NestJS (p. ej. `http://localhost:3001`). |
    | `NEXT_PUBLIC_CHATKIT_CDN` | (Opcional) CDN de ChatKit embebido. |
 
-3. **Instalar dependencias**
+3. **Instalar dependencias y preparar la base de datos**
 
    ```bash
    pnpm install
-   pnpm prisma migrate deploy --filter api
+   pnpm -C apps/api seed
    ```
+
+   El script `seed` ejecuta `prisma db push` y `prisma db seed` para actualizar el esquema y cargar datos iniciales. Consultá [`reports/backend-day1-summary.md`](reports/backend-day1-summary.md) para más detalles.
 
 4. **Levantar los servicios**
 
@@ -46,7 +48,15 @@ La integración permite:
    pnpm --filter web dev
    ```
 
-5. **Accesos y permisos**
+5. **Validar el backend (opcional pero recomendado)**
+
+   ```bash
+   pnpm -C apps/api test:report
+   ```
+
+   El resultado de la suite se guarda en [`reports/tests-day1.md`](reports/tests-day1.md).
+
+6. **Accesos y permisos**
 
    - La API key debe tener habilitado Agent Builder/AgentKit y evaluaciones.
    - Configurá CORS en el backend para el dominio del frontend (ya habilitado por defecto para `localhost`).

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,9 @@
     "start:prod": "node dist/main.js",
     "build": "tsc -p tsconfig.build.json",
     "start": "node dist/main.js",
-    "dev": "ts-node src/main.ts"
+    "dev": "ts-node src/main.ts",
+    "seed": "pnpm prisma db push && pnpm prisma db seed",
+    "test:report": "bash -c 'set -o pipefail && pnpm exec jest --config jest.config.ts 2>&1 | tee ../../reports/tests-day1.md'"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.8",

--- a/reports/backend-day1-summary.md
+++ b/reports/backend-day1-summary.md
@@ -1,0 +1,22 @@
+# Backend · Día 1
+
+## Entregables
+
+- **Sincronización del esquema Prisma y semillas iniciales**: ejecutar `pnpm -C apps/api seed` aplica el esquema actual con `prisma db push` y carga los datos de referencia definidos en [`apps/api/prisma/seed.ts`](../apps/api/prisma/seed.ts).
+- **Reporte de pruebas E2E**: ejecutar `pnpm -C apps/api test:report` corre la suite de Jest y guarda el resultado en [`reports/tests-day1.md`](./tests-day1.md).
+
+## Cómo ejecutar los scripts
+
+1. Asegurate de tener las variables de entorno del backend configuradas (`apps/api/.env`).
+2. Desde la raíz del monorepo:
+   - Sincronizá la base de datos y semillas con:
+     ```bash
+     pnpm -C apps/api seed
+     ```
+   - Generá el reporte de pruebas con:
+     ```bash
+     pnpm -C apps/api test:report
+     ```
+3. Revisá los artefactos generados:
+   - Datos sembrados: [`apps/api/prisma/seed.ts`](../apps/api/prisma/seed.ts)
+   - Resultado de las pruebas: [`reports/tests-day1.md`](./tests-day1.md)

--- a/reports/tests-day1.md
+++ b/reports/tests-day1.md
@@ -1,0 +1,9 @@
+PASS test/dashboard.e2e-spec.ts
+  DashboardController (e2e)
+    ✓ /dashboard/areas (GET) should return grouped metrics (30 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        2.329 s, estimated 4 s
+Ran all test suites.


### PR DESCRIPTION
## Summary
- add dedicated scripts in the API package for Prisma seeding and Jest reporting
- document Day 1 deliverables and reference the generated artifacts
- surface the new workflows in the top-level README and capture the Jest report

## Testing
- DATABASE_URL="file:./dev.db" pnpm -C apps/api seed
- DATABASE_URL="file:./dev.db" pnpm -C apps/api test:report

------
https://chatgpt.com/codex/tasks/task_e_68e73e6a11408325a2db271496102f24