### PR TITLE
Add scheduled audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,66 @@
+name: Agentic Platform Audit
+
+on:
+  schedule:
+    - cron: '0 */8 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run API tests
+        run: pnpm test
+        working-directory: apps/api
+
+      - name: Run Web tests
+        run: pnpm test
+        working-directory: apps/web
+
+      - name: Prepare reports directory
+        run: mkdir -p reports
+
+      - name: Run diagnostics (Markdown)
+        run: pnpm exec node reporter/agentic-audit.mjs --format markdown > reports/agent-audit.md
+
+      - name: Run diagnostics (JSON)
+        run: pnpm exec node reporter/agentic-audit.mjs --format json > reports/agent-audit.json
+
+      - name: Publish audit summary
+        run: cat reports/agent-audit.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Send audit email
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server: ${{ secrets.AUDIT_SMTP_SERVER }}
+          port: ${{ secrets.AUDIT_SMTP_PORT }}
+          secure: true
+          username: ${{ secrets.AUDIT_SMTP_USERNAME }}
+          password: ${{ secrets.AUDIT_SMTP_PASSWORD }}
+          subject: Agentic Platform Audit Report
+          from: ${{ secrets.AUDIT_MAIL_FROM }}
+          to: ${{ secrets.AUDIT_MAIL_TO }}
+          body: file://reports/agent-audit.md
+          attachments: |
+            reports/agent-audit.md
+            reports/agent-audit.json


### PR DESCRIPTION
## Summary
- add an Agentic Platform Audit workflow that runs on schedule, manual dispatch, and pushes to main
- install dependencies, run app tests, generate diagnostics reports, and send the audit email

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e73ea14b048325914b59bf545da7c5