### PR TITLE
Fix instruction text opacity class in AgentDetailsModal

### DIFF
--- a/apps/web/src/components/AgentDetailsModal.tsx
+++ b/apps/web/src/components/AgentDetailsModal.tsx
@@ -254,7 +254,7 @@ export function AgentDetailsModal({ agent, open, onClose }: AgentDetailsModalPro
               {detail.instructions && (
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-wide text-white/50">Instrucciones Base</p>
-                  <p className="mt-1 text-sm text-white/65 whitespace-pre-line">{detail.instructions}</p>
+                  <p className="mt-1 text-sm text-white/[0.65] whitespace-pre-line">{detail.instructions}</p>
                 </div>
               )}
             </article>


### PR DESCRIPTION
## Summary
- replace the unsupported Tailwind `text-white/65` class with the arbitrary opacity `text-white/[0.65]` to preserve the intended styling of the base instructions text

## Testing
- pnpm -C apps/web build *(fails: existing type error in apps/web/src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e73e74ca80832599a52fba8742acd5