### PR TITLE
Fix pdf-parse import for agent upload service

### DIFF
--- a/apps/api/src/agents/agent-upload.service.ts
+++ b/apps/api/src/agents/agent-upload.service.ts
@@ -3,7 +3,7 @@ import {
   Injectable,
   UnsupportedMediaTypeException
 } from '@nestjs/common'
-import { pdf as parsePdf } from 'pdf-parse'
+import parsePdf from 'pdf-parse'
 import { AgentRunnerService } from './agent-runner.service'
 import { AgentTraceService } from './tracing/agent-trace.service'
 


### PR DESCRIPTION
## Summary
- switch AgentUploadService to import the default export from pdf-parse so uploaded PDFs can be parsed at runtime

## Testing
- pnpm -C apps/api build *(fails: src/agents/agent-runner.service.ts:59:6 - error TS1005: ',' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68e7493464f883258be43f1f42eee22b