### PR TITLE
Ensure diagnostics script surfaces failures

### DIFF
--- a/scripts/agent-diagnostics.ts
+++ b/scripts/agent-diagnostics.ts
@@ -164,9 +164,13 @@ async function main() {
 
   const output = shouldOutputJson ? renderJson(results) : renderMarkdown(results);
   process.stdout.write(output);
+
+  if (results.some((result) => result.status !== 'passed')) {
+    process.exitCode = 1;
+  }
 }
 
 main().catch((error) => {
   console.error('Failed to run diagnostics:', error);
-  process.exitCode = 0;
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- ensure the diagnostics script sets a non-zero exit code when any check fails
- return a failing exit code when the script itself throws so CI detects the crash

## Testing
- pnpm exec tsx scripts/agent-diagnostics.ts --json *(fails: tsx command not found in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e74935973c8325b04734ed6198a7b5