### PR TITLE
Fix diagnostics health probe fallback

### DIFF
--- a/scripts/agent-diagnostics.ts
+++ b/scripts/agent-diagnostics.ts
@@ -23,7 +23,7 @@ interface CommandResult {
 const repoRoot = path.resolve(__dirname, '..')
 
 const HEALTH_PROBE_COMMAND =
-  process.env.AGENT_DIAGNOSTICS_HEALTH_COMMAND ?? 'pnpm exec node reporter/health-probe'
+  process.env.AGENT_DIAGNOSTICS_HEALTH_COMMAND ?? 'pnpm exec tsx scripts/api-health-probe.ts'
 const API_TEST_COMMAND =
   process.env.AGENT_DIAGNOSTICS_API_TEST_COMMAND ??
   'pnpm exec jest --config apps/api/jest.config.ts'

--- a/scripts/api-health-probe.ts
+++ b/scripts/api-health-probe.ts
@@ -1,0 +1,24 @@
+const DEFAULT_HEALTH_URL =
+  process.env.AGENT_DIAGNOSTICS_HEALTH_URL ?? 'http://localhost:3001/api/dashboard/areas'
+
+async function main() {
+  try {
+    const response = await fetch(DEFAULT_HEALTH_URL)
+
+    if (!response.ok) {
+      console.error(
+        `Health check failed for ${DEFAULT_HEALTH_URL}: ${response.status} ${response.statusText}`,
+      )
+      process.exitCode = 1
+      return
+    }
+
+    console.log(`Health check succeeded for ${DEFAULT_HEALTH_URL}`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Health check error for ${DEFAULT_HEALTH_URL}: ${message}`)
+    process.exitCode = 1
+  }
+}
+
+void main()


### PR DESCRIPTION
## Summary
- replace the diagnostics CLI default health probe with a real script under scripts/api-health-probe.ts
- implement the probe to call the dashboard endpoint and report success or errors instead of failing with ENOENT

## Testing
- pnpm dlx tsx scripts/api-health-probe.ts (fails in the container because outbound HTTPS is blocked)

------
https://chatgpt.com/codex/tasks/task_e_68e749368d088325af37dccd025168db