### PR TITLE
Address trace summary feedback type mismatch

### DIFF
--- a/apps/api/src/agents/agent-runner.service.ts
+++ b/apps/api/src/agents/agent-runner.service.ts
@@ -55,7 +55,6 @@ export class AgentRunnerService {
       ? {
           ...finalTrace,
           grade: evaluation.grade,
-          feedback: evaluation.feedback,
           evaluator: evaluation.evaluator
         }
       : finalTrace


### PR DESCRIPTION
## Summary
- drop the transient feedback property when returning trace summaries from the agent runner to keep the type contract with AgentTraceSummary

## Testing
- pnpm --filter ./apps/api... build *(fails: missing external dependencies and Prisma helpers in the existing tree)*

------
https://chatgpt.com/codex/tasks/task_e_68e74a8260f4832598f3ecbd03f2f07f