### PR TITLE
Restore evaluation feedback in agent traces

### DIFF
--- a/apps/api/src/agents/agent-runner.service.ts
+++ b/apps/api/src/agents/agent-runner.service.ts
@@ -55,6 +55,7 @@ export class AgentRunnerService {
       ? {
           ...finalTrace,
           grade: evaluation.grade,
+          feedback: evaluation.feedback,
           evaluator: evaluation.evaluator
         }
       : finalTrace

--- a/apps/api/src/agents/tracing/agent-trace.service.ts
+++ b/apps/api/src/agents/tracing/agent-trace.service.ts
@@ -8,6 +8,7 @@ const TRACE_SELECT = {
   runId: true,
   status: true,
   grade: true,
+  feedback: true,
   evaluator: true,
   traceUrl: true,
   input: true,
@@ -52,6 +53,7 @@ export class AgentTraceService {
     data: Partial<{
       status: string
       grade: number | null
+      feedback: string | null
       evaluator: string | null
       traceUrl: string | null
       output: unknown
@@ -60,6 +62,7 @@ export class AgentTraceService {
     const updateData = {
       status: data.status,
       grade: data.grade,
+      feedback: data.feedback,
       evaluator: data.evaluator,
       traceUrl: data.traceUrl,
       output: data.output !== undefined ? this.stringify(data.output) : undefined
@@ -152,6 +155,7 @@ type TraceRecord = {
   runId: string
   status: string
   grade: number | null
+  feedback: string | null
   evaluator: string | null
   traceUrl: string | null
   input: string | null


### PR DESCRIPTION
## Summary
- include the persisted feedback column in AgentTraceService selections and summaries
- return evaluator feedback from the agent runner when an evaluation is available

## Testing
- not run (pnpm --filter ./apps/api... build) *(fails: missing external dependencies and Prisma helpers in the existing tree)*

------
https://chatgpt.com/codex/tasks/task_e_68e74be7c5588325a3dfdf6cdbdb07c5