### PR TITLE
Validate rating payload before averaging

### DIFF
--- a/apps/api/src/agents/metrics/metrics.service.ts
+++ b/apps/api/src/agents/metrics/metrics.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 import { PrismaService } from '../../prisma/prisma.service'
 
@@ -49,7 +49,12 @@ export class MetricsService {
       throw new NotFoundException('Agent not found')
     }
 
-    const safeStars = Math.max(0, Math.min(5, stars))
+    const parsedStars = Number(stars)
+    if (!Number.isFinite(parsedStars)) {
+      throw new BadRequestException('Invalid rating payload: "stars" must be a finite number')
+    }
+
+    const safeStars = Math.max(0, Math.min(5, parsedStars))
     const calculatedAverage = agent.votes === 0 ? safeStars : (agent.stars * agent.votes + safeStars) / (agent.votes + 1)
     const newAverage = Number(calculatedAverage.toFixed(2))
 


### PR DESCRIPTION
## Summary
- add a BadRequest guard for the rating endpoint when the stars payload is not a finite number
- keep the clamping logic but run it after validation to prevent NaN averages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74d59391c83259bff3bf350925476