### PR TITLE
fix: align migration with agents schema and modal run endpoint

### DIFF
--- a/apps/api/prisma/migrations/20251008144705_add_enacom_agents_metrics/migration.sql
+++ b/apps/api/prisma/migrations/20251008144705_add_enacom_agents_metrics/migration.sql
@@ -2,23 +2,35 @@
 CREATE TABLE "Agent" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
+    "area" TEXT NOT NULL,
     "description" TEXT,
-    "area" TEXT,
-    "uses" INTEGER NOT NULL DEFAULT 0,
-    "downloads" INTEGER NOT NULL DEFAULT 0,
-    "rewards" INTEGER NOT NULL DEFAULT 0,
     "stars" REAL NOT NULL DEFAULT 0,
-    "votes" INTEGER NOT NULL DEFAULT 0,
-    "updatedAt" DATETIME NOT NULL
+    "votes" INTEGER NOT NULL DEFAULT 0
 );
 
 -- CreateTable
-CREATE TABLE "AgentUsage" (
+CREATE TABLE "Metrics" (
     "id" TEXT NOT NULL PRIMARY KEY,
+    "uses" INTEGER NOT NULL DEFAULT 0,
+    "downloads" INTEGER NOT NULL DEFAULT 0,
+    "rewards" INTEGER NOT NULL DEFAULT 0,
     "agentId" TEXT NOT NULL,
-    "action" TEXT NOT NULL,
-    "value" REAL,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "AgentUsage_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT "Metrics_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+-- CreateTable
+CREATE TABLE "Workflow" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'ready',
+    "model" TEXT NOT NULL DEFAULT 'gpt-4o',
+    "platform" TEXT NOT NULL DEFAULT 'OpenAI',
+    "agentId" TEXT NOT NULL,
+    CONSTRAINT "Workflow_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metrics_agentId_key" ON "Metrics"("agentId");
+
+-- CreateIndex
+CREATE INDEX "Workflow_agentId_idx" ON "Workflow"("agentId");

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -204,7 +204,7 @@ function AgentWorkflowModal({ agent, onClose }: WorkflowModalProps) {
     if (!agent) return
     setBusy(true)
     try {
-      const res = await fetch(`/api/agents/${agent.id}/run`, {
+      const res = await fetch(`/api/agents/${agent.id}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ input, action })


### PR DESCRIPTION
## Summary
- update the initial Prisma migration so it creates the Agent, Metrics, and Workflow tables that match the current schema
- point the dashboard modal workflow runner to the existing /api/agents/[id] POST handler instead of a non-existent /run route

## Testing
- npx prisma validate *(fails: missing DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68e74d5676bc832593d2fcf50ade037a