### PR TITLE
Add migration for AgentKit metadata and trace tables

### DIFF
--- a/apps/api/prisma/migrations/20251009055152_add_agentkit_metadata_and_traces/migration.sql
+++ b/apps/api/prisma/migrations/20251009055152_add_agentkit_metadata_and_traces/migration.sql
@@ -1,0 +1,19 @@
+-- Add AgentKit metadata columns to Agent
+ALTER TABLE "Agent" ADD COLUMN "openaiAgentId" TEXT;
+ALTER TABLE "Agent" ADD COLUMN "model" TEXT DEFAULT 'gpt-4.1-mini';
+ALTER TABLE "Agent" ADD COLUMN "instructions" TEXT;
+
+-- Create AgentTrace table for AgentKit runs
+CREATE TABLE "AgentTrace" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "agentId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "grade" REAL,
+    "evaluator" TEXT,
+    "traceUrl" TEXT,
+    "input" TEXT,
+    "output" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AgentTrace_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);


### PR DESCRIPTION
## Summary
- add Prisma migration to introduce AgentKit metadata columns on Agent
- create AgentTrace table to support persisted traces with cascading agent cleanup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e74d53ce6883259ab7835fab19a742