### PR TITLE
fix: restore DATABASE_URL after day1 e2e cleanup

### DIFF
--- a/apps/api/test/day1-agents.e2e-spec.ts
+++ b/apps/api/test/day1-agents.e2e-spec.ts
@@ -65,6 +65,7 @@ describe('Agents API Day 1 flows (e2e)', () => {
   let server: any
   let databaseFile: string
   let previousDatabaseUrl: string | undefined
+  let hadDatabaseUrl = false
   let prismaClientReady = false
 
   const seedAgents = [
@@ -102,6 +103,7 @@ describe('Agents API Day 1 flows (e2e)', () => {
     databaseFile = join(__dirname, 'tmp', `day1-${randomUUID()}.sqlite`)
     mkdirSync(dirname(databaseFile), { recursive: true })
     const databaseUrl = `file:${databaseFile}`
+    hadDatabaseUrl = Object.prototype.hasOwnProperty.call(process.env, 'DATABASE_URL')
     previousDatabaseUrl = process.env.DATABASE_URL
     process.env.DATABASE_URL = databaseUrl
 
@@ -144,8 +146,10 @@ describe('Agents API Day 1 flows (e2e)', () => {
     if (app) {
       await app.close()
     }
-    if (previousDatabaseUrl !== undefined) {
+    if (hadDatabaseUrl) {
       process.env.DATABASE_URL = previousDatabaseUrl
+    } else {
+      delete process.env.DATABASE_URL
     }
     try {
       rmSync(databaseFile, { force: true })


### PR DESCRIPTION
## Summary
- track whether DATABASE_URL was defined before the Day 1 e2e suite runs
- restore the previous value or remove the variable during teardown so later suites inherit the original environment

## Testing
- pnpm test -- --runTestsByPath apps/api/test/day1-agents.e2e-spec.ts *(fails: ReferenceError: HttpCode is not defined in agent-run.controller)*

------
https://chatgpt.com/codex/tasks/task_e_68e74d42632483258f863db08c45b1f8