### PR TITLE
Normalize agent types when loading agents

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -58,10 +58,11 @@ export default function Page() {
         const res = await fetch(`${API_BASE_URL}/agents`, { cache: 'no-store' })
         if (!res.ok) throw new Error('No se pudieron obtener los agentes del ENACOM')
 
-        const data = (await res.json()) as AgentSummary[]
-        const enriched = data.map((agent) => ({
+        const data = (await res.json()) as ApiAgent[]
+        const enriched: AgentSummary[] = data.map((agent) => ({
           ...agent,
-          type: (agent.type as AgentCategory) ?? inferAgentType(agent.name)
+          description: agent.description ?? null,
+          type: normalizeCategory(agent.type)
         }))
         setAgents(enriched)
         setError(null)


### PR DESCRIPTION
## Summary
- normalize agent data from the API so every record uses one of the supported categories
- ensure description defaults to null while preserving other agent fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74d1747f88325a1bfb881403c0e52