### PR TITLE
Fix pdf-parse import without esModuleInterop

### DIFF
--- a/apps/api/src/agents/agent-upload.service.ts
+++ b/apps/api/src/agents/agent-upload.service.ts
@@ -3,7 +3,7 @@ import {
   Injectable,
   UnsupportedMediaTypeException
 } from '@nestjs/common'
-import parsePdf from 'pdf-parse'
+import parsePdf = require('pdf-parse')
 import { AgentRunnerService } from './agent-runner.service'
 import { AgentTraceService } from './tracing/agent-trace.service'
 


### PR DESCRIPTION
## Summary
- switch AgentUploadService to use a CommonJS-compatible require import for pdf-parse so the runtime receives the parser function

## Testing
- pnpm -C apps/api build *(fails: src/agents/agent-runner.service.ts:59:6 - error TS1005: ',' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68e74ca1e25c832594abb74b60489927