### PR TITLE
Set type for new regulatory and reporting seeds

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -21,6 +21,7 @@ async function main() {
       },
       {
         name: 'Gestión Regulatoria',
+        type: 'regulatory',
         description: 'Monitorea el cumplimiento normativo y los procesos de licenciamiento TIC.',
         area: 'Gestión Regulatoria y Licencias',
         uses: 58,
@@ -31,6 +32,7 @@ async function main() {
       },
       {
         name: 'Reportes e Informes',
+        type: 'reporting',
         description: 'Genera tableros ejecutivos y reportes institucionales automatizados.',
         area: 'Reportes e Informes Institucionales',
         uses: 87,


### PR DESCRIPTION
## Summary
- set explicit regulatory type for the Gestión Regulatoria demo agent to ensure correct grouping
- add reporting type to the Reportes e Informes demo agent for consistency with dashboard categories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e74c141a04832591471c369c5674a1