### PR TITLE
Ensure diagnostics script exits on failure

### DIFF
--- a/scripts/agent-diagnostics.ts
+++ b/scripts/agent-diagnostics.ts
@@ -165,12 +165,14 @@ async function main() {
   const output = shouldOutputJson ? renderJson(results) : renderMarkdown(results);
   process.stdout.write(output);
 
-  if (results.some((result) => result.status !== 'passed')) {
+  const hasFailures = results.some((result) => result.status !== 'passed');
+  if (hasFailures) {
+    console.error('One or more diagnostics checks did not pass.');
     process.exitCode = 1;
   }
 }
 
 main().catch((error) => {
   console.error('Failed to run diagnostics:', error);
-  process.exitCode = 1;
+  process.exitCode = process.exitCode && process.exitCode !== 0 ? process.exitCode : 1;
 });


### PR DESCRIPTION
## Summary
- set a non-zero exit code when any diagnostics check fails and log the failure
- keep the process exit code non-zero when the diagnostics runner crashes unexpectedly

## Testing
- pnpm exec tsx scripts/agent-diagnostics.ts --json *(fails because current diagnostics do not pass, confirming the script exits with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68e74c05bb588325a976a6438246c5d1