### PR TITLE
fix: ensure all agent categories render in dashboard

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -88,6 +88,11 @@ export default function Page() {
   }, [agents, filter, search, sortKey])
 
   const groupedByCategory = useMemo(() => {
+    const emptyGroups = orderedColumns.reduce<Record<AgentCategory, AgentSummary[]>>((acc, category) => {
+      acc[category] = []
+      return acc
+    }, {} as Record<AgentCategory, AgentSummary[]>)
+
     return filteredAgents.reduce<Record<AgentCategory, AgentSummary[]>>((acc, agent) => {
       const category = normalizeCategory(agent.type)
       if (!acc[category]) {
@@ -95,7 +100,7 @@ export default function Page() {
       }
       acc[category].push(agent)
       return acc
-    }, { technical: [], financial: [], regulatory: [], reporting: [], risk: [], planning: [], general: [] } as Record<AgentCategory, AgentSummary[]>)
+    }, emptyGroups)
   }, [filteredAgents])
 
   return (


### PR DESCRIPTION
## Summary
- build the grouped agents map from the canonical ordered agent types so every category is initialized

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e74c6006288325bdb365347446bf02