### PR TITLE
Guard Prisma postinstall script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/main.js",
     "dev": "ts-node src/main.ts",
     "test": "jest --config jest.config.ts --runInBand",
-    "postinstall": "prisma generate"
+    "postinstall": "node ./scripts/prisma-postinstall.js"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.8",

--- a/apps/api/scripts/prisma-postinstall.js
+++ b/apps/api/scripts/prisma-postinstall.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const { join } = require('path');
+const { existsSync } = require('fs');
+const { spawnSync } = require('child_process');
+
+const binName = process.platform === 'win32' ? 'prisma.cmd' : 'prisma';
+const prismaBinary = join(process.cwd(), 'node_modules', '.bin', binName);
+
+if (!existsSync(prismaBinary)) {
+  console.log('Prisma CLI not found; skipping `prisma generate`.');
+  process.exit(0);
+}
+
+const result = spawnSync(prismaBinary, ['generate'], { stdio: 'inherit' });
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(result.status ?? 1);
+}
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- update the API package postinstall hook to run through a guarded Node script
- add a postinstall helper that only invokes `prisma generate` when the CLI is available

## Testing
- node apps/api/scripts/prisma-postinstall.js

------
https://chatgpt.com/codex/tasks/task_e_68e74d40203c8325a3c3115af44e283c