### PR TITLE
Fix audit workflow build and email configuration

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run API tests
-        run: pnpm test
+      - name: Build API application
+        run: pnpm build
         working-directory: apps/api
 
-      - name: Run Web tests
-        run: pnpm test
+      - name: Build Web application
+        run: pnpm build
         working-directory: apps/web
 
       - name: Prepare reports directory
@@ -52,8 +52,8 @@ jobs:
       - name: Send audit email
         uses: dawidd6/action-send-mail@v3
         with:
-          server: ${{ secrets.AUDIT_SMTP_SERVER }}
-          port: ${{ secrets.AUDIT_SMTP_PORT }}
+          server_address: ${{ secrets.AUDIT_SMTP_SERVER }}
+          server_port: ${{ secrets.AUDIT_SMTP_PORT }}
           secure: true
           username: ${{ secrets.AUDIT_SMTP_USERNAME }}
           password: ${{ secrets.AUDIT_SMTP_PASSWORD }}


### PR DESCRIPTION
## Summary
- replace placeholder pnpm test invocations with build steps for the API and web apps
- configure the audit email step with the correct server_address and server_port inputs for dawidd6/action-send-mail

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e74d3e6cc88325a59c7ad31be26d93