### PR TITLE
fix(api): stabilize build pipeline across platforms

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/main.js",
     "dev": "ts-node src/main.ts",
     "test": "jest --config jest.config.ts --runInBand",
-    "postinstall": "node ./scripts/prisma-postinstall.js"
+    "postinstall": "pnpm prisma generate"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.8",
@@ -28,7 +28,7 @@
     "@nestjs/schematics": "^10.1.3",
     "@nestjs/testing": "^10.4.8",
     "@types/express": "^4.17.23",
-    "@types/multer": "^1.4.12",
+    "@types/multer": "^1.4.13",
     "@types/node": "^24.7.0",
     "prisma": "^5.22.0",
     "ts-node": "^10.9.2",

--- a/apps/api/scripts/prisma-postinstall.js
+++ b/apps/api/scripts/prisma-postinstall.js
@@ -1,17 +1,7 @@
 #!/usr/bin/env node
-const { join } = require('path');
-const { existsSync } = require('fs');
 const { spawnSync } = require('child_process');
-
-const binName = process.platform === 'win32' ? 'prisma.cmd' : 'prisma';
-const prismaBinary = join(process.cwd(), 'node_modules', '.bin', binName);
-
-if (!existsSync(prismaBinary)) {
-  console.log('Prisma CLI not found; skipping `prisma generate`.');
-  process.exit(0);
-}
-
-const result = spawnSync(prismaBinary, ['generate'], { stdio: 'inherit' });
+const runner = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const result = spawnSync(runner, ['prisma', 'generate'], { stdio: 'inherit' });
 
 if (result.error) {
   console.error(result.error);

--- a/apps/api/src/agents/agent-eval.service.ts
+++ b/apps/api/src/agents/agent-eval.service.ts
@@ -43,14 +43,22 @@ export class AgentEvalService {
 
   constructor(private prisma: PrismaService) {
     const apiKey = process.env.OPENAI_API_KEY
-    if (apiKey) {
-      this.openai = new OpenAI({
-        apiKey,
-        organization: process.env.OPENAI_ORG_ID,
-        project: process.env.OPENAI_PROJECT_ID
-      })
-    } else {
+    if (!apiKey) {
+      console.warn('⚠️ Missing OPENAI_API_KEY — OpenAI client disabled.')
+      this.logger.warn('OPENAI_API_KEY is not configured. Auto-evaluation will be skipped.')
       this.openai = null
+    } else {
+      try {
+        this.openai = new OpenAI({
+          apiKey,
+          organization: process.env.OPENAI_ORG_ID,
+          project: process.env.OPENAI_PROJECT_ID
+        })
+      } catch (error) {
+        console.warn('⚠️ Missing OPENAI_API_KEY — OpenAI client disabled.')
+        this.logger.error('Failed to initialize the OpenAI client. Auto-evaluation will be skipped.', error as Error)
+        this.openai = null
+      }
     }
 
     this.template = this.resolveTemplate(process.env.OPENAI_EVAL_TEMPLATE)

--- a/apps/api/src/agents/agent-upload.controller.ts
+++ b/apps/api/src/agents/agent-upload.controller.ts
@@ -10,7 +10,7 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import multer from 'multer';
 import { AgentUploadService } from './agent-upload.service';
-import type { Express } from 'express';
+import type { AgentUploadFile } from './agent-upload.service';
 
 @Controller('agents/:id')
 export class AgentUploadController {
@@ -30,7 +30,7 @@ export class AgentUploadController {
         .addMaxSizeValidator({ maxSize: 10 * 1024 * 1024 })
         .build({ errorHttpStatusCode: HttpStatus.UNSUPPORTED_MEDIA_TYPE }),
     )
-    file: Express.Multer.File,
+    file: AgentUploadFile,
   ) {
     return this.uploadService.processFinancialReport(agentId, file);
   }

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "sourceMap": true,
     "removeComments": true,
-    "incremental": true
+    "incremental": true,
+    "types": ["node", "express", "multer"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         specifier: ^4.17.23
         version: 4.17.23
       '@types/multer':
-        specifier: ^1.4.12
+        specifier: ^1.4.13
         version: 1.4.13
       '@types/node':
         specifier: ^24.7.0


### PR DESCRIPTION
## Summary
- replace the API postinstall hook with a cross-platform prisma generate call and keep the helper script compatible with Windows
- ensure multer typings are available in build output and wire the upload controller to the shared file alias
- make the OpenAI client initialization resilient to missing credentials and expose multer/express types to the compiler

## Testing
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68e75efce9248325a8a44e9d1c05d7c6