### PR TITLE
Fix pdf-parse import for CJS build

### DIFF
--- a/apps/api/src/agents/agent-upload.service.ts
+++ b/apps/api/src/agents/agent-upload.service.ts
@@ -3,7 +3,7 @@ import {
   Injectable,
   UnsupportedMediaTypeException
 } from '@nestjs/common'
-import parsePdf from 'pdf-parse'
+import * as parsePdf from 'pdf-parse'
 import { AgentRunnerService } from './agent-runner.service'
 import { AgentTraceService } from './tracing/agent-trace.service'
 


### PR DESCRIPTION
## Summary
- switch the pdf-parse import to a namespace import so it resolves correctly under the API's CommonJS build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e75f0373d483259409f88abed12301