### PR TITLE
fix: execute eval runs for auto grading

### DIFF
--- a/apps/api/prisma/migrations/20240606120000_add_feedback_to_agent_trace/migration.sql
+++ b/apps/api/prisma/migrations/20240606120000_add_feedback_to_agent_trace/migration.sql
@@ -1,0 +1,2 @@
+-- Add feedback column to AgentTrace table
+ALTER TABLE "AgentTrace" ADD COLUMN "feedback" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -40,6 +40,7 @@ model AgentTrace {
   status    String
   grade     Float?
   evaluator String?
+  feedback  String?
   traceUrl  String?
   input     String?
   output    String?


### PR DESCRIPTION
## Summary
- add a `feedback` column to the `AgentTrace` Prisma model so auto-eval results can be stored
- create a Prisma migration to add the new column in the database schema

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e751e285888325a4532d72383fa8d2