### PR TITLE
Fix pdf-parse invocation for upload handling

### DIFF
--- a/apps/api/src/agents/agent-upload.service.ts
+++ b/apps/api/src/agents/agent-upload.service.ts
@@ -12,7 +12,7 @@ export type AgentUploadFile = Express.Multer.File;
 
 type PdfParser = (data: Buffer | Uint8Array, options?: unknown) => Promise<{ text?: string }>
 
-const parsePdfBuffer = parsePdf as unknown as PdfParser
+const parsePdfBuffer: PdfParser = (data, options) => parsePdf(data, options)
 
 @Injectable()
 export class AgentUploadService {


### PR DESCRIPTION
## Summary
- restore use of the pdf-parse default export and wrap it with a typed helper to keep existing call sites working

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e93c1ee2408325903ca19d267154ec