### PR TITLE
fix: return feedback in agent trace service

### DIFF
--- a/apps/api/src/agents/tracing/agent-trace.service.ts
+++ b/apps/api/src/agents/tracing/agent-trace.service.ts
@@ -8,6 +8,7 @@ const TRACE_SELECT = {
   status: true,
   grade: true,
   evaluator: true,
+  feedback: true,
   traceUrl: true,
   input: true,
   output: true,
@@ -142,6 +143,7 @@ type TraceRecord = {
   status: string
   grade: number | null
   evaluator: string | null
+  feedback: string | null
   traceUrl: string | null
   input: string | null
   output: string | null


### PR DESCRIPTION
## Summary
- include the feedback column when selecting trace records
- expose the feedback field through the AgentTrace types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea879d4aac8325a86988eaf682fccb