### PR TITLE
Remove type column from temporary Agent schema

### DIFF
--- a/apps/api/test/day1-agents.e2e-spec.ts
+++ b/apps/api/test/day1-agents.e2e-spec.ts
@@ -222,7 +222,6 @@ async function applySchema(prisma: PrismaService) {
     CREATE TABLE IF NOT EXISTS "Agent" (
       "id" TEXT PRIMARY KEY,
       "name" TEXT NOT NULL,
-      "type" TEXT NOT NULL DEFAULT 'Analyst',
       "area" TEXT NOT NULL,
       "description" TEXT,
       "uses" INTEGER NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- align the temporary Agent table definition used in e2e tests with the current Prisma schema by dropping the obsolete `type` column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea87b948f8832584307024016c069b