### PR TITLE
Handle missing ENACOM API base URL

### DIFF
--- a/apps/web/src/app/api/agents/_utils.ts
+++ b/apps/web/src/app/api/agents/_utils.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server'
 
 const DEFAULT_API_URL = 'http://localhost:3001/api'
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL ?? DEFAULT_API_URL
+const API_BASE_URL =
+  resolveApiBaseUrl(process.env.NEXT_PUBLIC_API_URL, process.env.API_URL) ?? DEFAULT_API_URL
 
 type ForwardInit = RequestInit & { json?: unknown }
 
@@ -19,8 +20,14 @@ export async function forwardToEnacom(path: string, init: ForwardInit = {}) {
     cache: 'no-store'
   }
 
-  const response = await fetch(`${API_BASE_URL}${path}`, requestInit)
-  return nextResponseFromFetch(response)
+  try {
+    const url = createTargetUrl(path)
+    const response = await fetch(url, requestInit)
+    return nextResponseFromFetch(response)
+  } catch (error) {
+    console.error('Error reenviando solicitud al API de ENACOM:', error)
+    return NextResponse.json({ message: 'Error interno al contactar el API de ENACOM' }, { status: 500 })
+  }
 }
 
 export async function nextResponseFromFetch(response: Response) {
@@ -44,4 +51,29 @@ function safeJsonParse(text: string) {
     console.error('Error al parsear JSON del API ENACOM:', error)
     return text
   }
+}
+
+function resolveApiBaseUrl(...values: Array<string | undefined>) {
+  for (const value of values) {
+    const normalized = normalizeEnvValue(value)
+    if (normalized) {
+      return normalized
+    }
+  }
+  return undefined
+}
+
+function normalizeEnvValue(value: string | undefined) {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed === 'undefined' || trimmed === 'null') {
+    return undefined
+  }
+  return trimmed.replace(/\/$/, '')
+}
+
+function createTargetUrl(path: string) {
+  const baseUrl = API_BASE_URL.replace(/\/$/, '')
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${baseUrl}${normalizedPath}`
 }


### PR DESCRIPTION
## Summary
- sanitize the ENACOM proxy base URL so literal "undefined" values fall back to the local default
- normalize forwarded request URLs and add guarded error handling when contacting the ENACOM API

## Testing
- pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68ed6a4b8b008325b9c37df3c555253f