### PR TITLE
feat: persist sdk agents and expose dashboard data

### DIFF
--- a/apps/web/src/app/api/agents/create/route.ts
+++ b/apps/web/src/app/api/agents/create/route.ts
@@ -1,64 +1,6 @@
-import { NextResponse } from 'next/server'
+import { forwardToEnacom } from '../_utils';
 
 export async function POST(req: Request) {
-  const apiUrl = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL
-
-  if (!apiUrl) {
-    return NextResponse.json(
-      { message: 'API_URL environment variable is not defined.' },
-      { status: 500 }
-    )
-  }
-
-  let targetUrl: string
-  try {
-    targetUrl = new URL('/agents/create', apiUrl).toString()
-  } catch (error) {
-    console.error('Invalid API_URL value:', apiUrl, error)
-    return NextResponse.json(
-      { message: 'API_URL environment variable has an invalid value.' },
-      { status: 500 }
-    )
-  }
-
-  const body = await req.json()
-
-  try {
-    const response = await fetch(targetUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-
-    const contentType = response.headers.get('content-type') ?? ''
-    if (!response.ok) {
-      const errorPayload = contentType.includes('application/json')
-        ? await response.json()
-        : await response.text()
-
-      return NextResponse.json(
-        { message: 'Upstream API request failed', details: errorPayload },
-        { status: response.status }
-      )
-    }
-
-    const data = contentType.includes('application/json')
-      ? await response.json()
-      : await response.text()
-
-    if (typeof data === 'string') {
-      return NextResponse.json({ data })
-    }
-
-    return NextResponse.json(data)
-  } catch (error) {
-    console.error('Error proxying agent creation request:', error)
-    return NextResponse.json(
-      {
-        message: 'Failed to reach upstream API',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    )
-  }
+  const body = await req.json();
+  return forwardToEnacom('/agents/create', { method: 'POST', json: body });
 }

--- a/apps/web/src/app/api/dashboard/leaderboard/route.ts
+++ b/apps/web/src/app/api/dashboard/leaderboard/route.ts
@@ -1,0 +1,5 @@
+import { forwardToEnacom } from '../../agents/_utils';
+
+export async function GET() {
+  return forwardToEnacom('/dashboard/leaderboard');
+}

--- a/apps/web/src/components/agents/SDKAgentBuilderModal.tsx
+++ b/apps/web/src/components/agents/SDKAgentBuilderModal.tsx
@@ -18,6 +18,7 @@ const assistant = await client.beta.assistants.create({
 
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState<any>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const router = useRouter()
 
   useEffect(() => {
@@ -29,12 +30,19 @@ const assistant = await client.beta.assistants.create({
   const handleCreate = async () => {
     try {
       setLoading(true)
+      setErrorMessage(null)
       const res = await fetch('/api/agents/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ mode: 'sdk', code }),
       })
       const data = await res.json()
+
+      if (!res.ok) {
+        const message = typeof data?.message === 'string' ? data.message : 'No se pudo crear el agente'
+        throw new Error(message)
+      }
+
       console.log('✅ Agente creado:', data)
       setResult(data)
 
@@ -44,7 +52,9 @@ const assistant = await client.beta.assistants.create({
         router.push('/agents')
       }, 1500)
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error desconocido'
       console.error('❌ Error creando agente:', err)
+      setErrorMessage(message)
     } finally {
       setLoading(false)
     }
@@ -70,11 +80,33 @@ const assistant = await client.beta.assistants.create({
           </Button>
         </div>
 
+        {errorMessage && (
+          <div className="mt-6 text-sm text-red-300 border-t border-slate-700 pt-4">
+            ❌ Error: <span className="text-red-200">{errorMessage}</span>
+          </div>
+        )}
+
         {result && (
           <div className="mt-6 text-sm text-slate-300 border-t border-slate-700 pt-4">
-            ✅ Agente creado: <span className="text-emerald-400">{result.name}</span>
+            <div className="font-semibold text-emerald-400">✅ {result.message ?? 'Agente creado'}</div>
+            {result.agent?.name && (
+              <>
+                Nombre: <span className="text-emerald-400">{result.agent.name}</span>
+                <br />
+              </>
+            )}
+            {result.agent?.area && (
+              <>
+                Área: <span className="text-emerald-300">{result.agent.area}</span>
+                <br />
+              </>
+            )}
             <br />
-            🆔 ID: <code className="text-emerald-300">{result.assistant_id}</code>
+            🆔 Assistant ID:{' '}
+            <code className="text-emerald-300">{result.assistant_id ?? '—'}</code>
+            <br />
+            🆔 Agent ID:{' '}
+            <code className="text-emerald-300">{result.agent?.id ?? '—'}</code>
             <br />
             🔄 Redirigiendo a la vista de agentes...
           </div>


### PR DESCRIPTION
## Summary
- persist SDK-created agents in Prisma while creating the upstream assistant
- add proxy routes so the web app can call the Nest dashboard leaderboard API
- improve the SDK builder modal feedback and error handling when creating agents

## Testing
- `pnpm --filter api test -- --runInBand` *(fails: existing e2e suites expect mocked OpenAI eval APIs and /health route without global prefix)*

------
https://chatgpt.com/codex/tasks/task_e_68ed721c9254832593bfe9385b8c8104