### PR TITLE
Ensure AgentTrace feedback column exists on startup

### DIFF
--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -1,13 +1,45 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
+type TableInfoRow = {
+  name: string;
+};
+
+type TableExistenceRow = {
+  name: string;
+};
+
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
   async onModuleInit(): Promise<void> {
     await this.$connect();
+    await this.ensureAgentTraceFeedbackColumn();
   }
 
   async onModuleDestroy(): Promise<void> {
     await this.$disconnect();
+  }
+
+  private async ensureAgentTraceFeedbackColumn(): Promise<void> {
+    try {
+      const tableExists = (await this.$queryRaw`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'AgentTrace'
+      `) as TableExistenceRow[];
+
+      if (!tableExists.length) {
+        return;
+      }
+
+      const columns = (await this.$queryRaw`PRAGMA table_info("AgentTrace")`) as TableInfoRow[];
+      const hasFeedbackColumn = columns.some((column) => column.name === 'feedback');
+
+      if (!hasFeedbackColumn) {
+        await this.$executeRawUnsafe('ALTER TABLE "AgentTrace" ADD COLUMN "feedback" TEXT;');
+      }
+    } catch (error) {
+      console.error('Failed to ensure AgentTrace.feedback column exists:', error);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure the Prisma service checks the AgentTrace table for the feedback column on startup
- add a lightweight migration guard that creates the feedback column when it is missing
- gracefully skip the check when the AgentTrace table has not been created yet

## Testing
- pnpm --filter api test *(fails: openai beta SDK mock mismatch and missing /health route expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68ed7ca0c3a883259f6b25a275e57a3b