### PR TITLE
fix: extend prisma client stub with raw query methods

### DIFF
--- a/apps/api/src/prisma/prisma-client.d.ts
+++ b/apps/api/src/prisma/prisma-client.d.ts
@@ -2,6 +2,11 @@ declare module '@prisma/client' {
   export class PrismaClient {
     $connect: () => Promise<void>
     $disconnect: () => Promise<void>
+    $queryRaw: <T = unknown>(
+      query: TemplateStringsArray | string,
+      ...values: unknown[]
+    ) => Promise<T>
+    $executeRawUnsafe: (query: string, ...values: unknown[]) => Promise<number>
     agent: {
       findMany: (...args: unknown[]) => Promise<any>
       findUnique: (...args: unknown[]) => Promise<any>


### PR DESCRIPTION
## Summary
- add $queryRaw and $executeRawUnsafe definitions to the PrismaClient stub used in tests
- allow prisma service to use raw queries without type errors

## Testing
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68ed7f0b45608325bf962730e8cce54c