### PR TITLE
Improve agent creation API proxy error handling

### DIFF
--- a/apps/web/src/app/api/agents/create/route.ts
+++ b/apps/web/src/app/api/agents/create/route.ts
@@ -12,7 +12,11 @@ export async function POST(req: Request) {
 
   let targetUrl: string
   try {
-    targetUrl = new URL('/agents/create', apiUrl).toString()
+    const url = new URL(apiUrl)
+    url.pathname = url.pathname.endsWith('/')
+      ? `${url.pathname}agents/create`
+      : `${url.pathname}/agents/create`
+    targetUrl = url.toString()
   } catch (error) {
     console.error('Invalid API_URL value:', apiUrl, error)
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- preserve any existing path segment from API_URL when building the upstream agent creation endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed7f3af4b8832597a76b31762c8134