### PR TITLE
Fix connector icon map typing in AgentCapabilitiesModal

### DIFF
--- a/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
+++ b/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChangeEvent, ComponentType, useEffect, useMemo, useRef, useState } from 'react'
+import { ChangeEvent, ComponentType, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import {
   Brain,
   Calendar,
@@ -408,7 +408,7 @@ export function AgentCapabilitiesModal({ agent, open, onClose, onToolsChange }: 
     return null
   }
 
-  const connectorIconMap: Record<string, JSX.Element> = {
+  const connectorIconMap: Record<string, ReactNode> = {
     connector_dropbox: <Cloud className="h-5 w-5 text-sky-300" />,
     connector_gmail: <Mail className="h-5 w-5 text-red-400" />,
     connector_googlecalendar: <Calendar className="h-5 w-5 text-blue-300" />,


### PR DESCRIPTION
## Summary
- update AgentCapabilitiesModal to import the ReactNode type from React
- type the connector icon mapping with ReactNode instead of JSX.Element to avoid namespace errors

## Testing
- pnpm --filter web build *(fails: Type error: Cannot find name 'forwardToEnacom' in apps/web/src/app/api/agents/create/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ed925483688325997b95f4f4c7f5c5