### PR TITLE
Fix agent creation proxy path handling

### DIFF
--- a/apps/web/src/app/api/agents/create/route.ts
+++ b/apps/web/src/app/api/agents/create/route.ts
@@ -1,4 +1,4 @@
-import { forwardToEnacom } from '../_utils';
+import { NextResponse } from 'next/server'
 
 export async function POST(req: Request) {
   const apiUrl = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL
@@ -13,9 +13,11 @@ export async function POST(req: Request) {
   let targetUrl: string
   try {
     const url = new URL(apiUrl)
-    url.pathname = url.pathname.endsWith('/')
-      ? `${url.pathname}agents/create`
-      : `${url.pathname}/agents/create`
+    const normalizedBasePath = url.pathname.replace(/\/+$/, '')
+    const joinedPath = [normalizedBasePath, 'agents', 'create']
+      .filter(Boolean)
+      .join('/')
+    url.pathname = joinedPath.startsWith('/') ? joinedPath : `/${joinedPath}`
     targetUrl = url.toString()
   } catch (error) {
     console.error('Invalid API_URL value:', apiUrl, error)


### PR DESCRIPTION
## Summary
- normalize the upstream API base path before appending the agent creation endpoint
- ensure the proxy still validates the configured API_URL and preserves any existing path prefix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed95dbd7788325929b79b188aa35e9