### PR TITLE
Follow-up: Widen ConnectorCard icon prop to ReactNode

### DIFF
--- a/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
+++ b/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
@@ -834,7 +834,7 @@ function SearchTypeCard({ type: _type, label, description, icon: Icon, active, o
 
 type ConnectorCardProps = {
   connector: MCPConnector
-  icon?: JSX.Element
+  icon?: ReactNode
   onRemove: (id: string) => void
   onConfigure: (connector: MCPConnector) => void
 }


### PR DESCRIPTION
## Summary
- update ConnectorCardProps to accept a ReactNode for the icon to match the connector icon map

## Testing
- not run (type checking currently blocked by unrelated forwardToEnacom error)

------
https://chatgpt.com/codex/tasks/task_e_68ed95ef9ad48325bc3357a41682e0c4