### PR TITLE
Address review feedback for capability modal state resets

### DIFF
--- a/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
+++ b/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
@@ -161,9 +161,12 @@ export function AgentCapabilitiesModal({ agent, open, onClose, onToolsChange }: 
 
   useEffect(() => {
     setToolsState(agent?.tools ?? null)
+  }, [agent?.id, agent?.tools])
+
+  useEffect(() => {
     setNewDomain('')
     setMetadataFilter({ type: 'in', key: '', value: '' })
-  }, [agent])
+  }, [agent?.id])
 
   const tools = toolsState ?? agent?.tools ?? null
 


### PR DESCRIPTION
## Summary
- stop resetting staged capability edits when toggling controls by syncing tools state without clearing form helpers
- reset domain and metadata filter inputs only when the selected agent changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed96031e0c8325b07cff90771215ce