### PR TITLE
Fix connector icon map typing in AgentCapabilitiesModal

### DIFF
--- a/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
+++ b/apps/web/src/components/agents/AgentCapabilitiesModal.tsx
@@ -834,7 +834,7 @@ function SearchTypeCard({ type: _type, label, description, icon: Icon, active, o
 
 type ConnectorCardProps = {
   connector: MCPConnector
-  icon?: JSX.Element
+  icon?: ReactNode
   onRemove: (id: string) => void
   onConfigure: (connector: MCPConnector) => void
 }


### PR DESCRIPTION
## Summary
- widen the `ConnectorCard` icon prop to accept `ReactNode` so it matches the connector icon map entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed95b6bec08325995a49d2cb560945